### PR TITLE
Implement phase 1 hardened UX features

### DIFF
--- a/docs/assets/calculation.js
+++ b/docs/assets/calculation.js
@@ -15,40 +15,60 @@ function isNumber(value) {
 }
 
 export function validateInputs(anchor, greenPct, yellowPct) {
-  if (!isNumber(anchor) || !isNumber(greenPct) || !isNumber(yellowPct)) {
-    return { valid: false, message: 'Anchor and deviation values must be numbers.' };
+  const errors = {};
+
+  if (!isNumber(anchor)) {
+    errors.anchor = 'Anchor BPM must be a number.';
+  } else if (!Number.isInteger(anchor)) {
+    errors.anchor = 'Anchor BPM must be a whole number.';
   }
 
-  if (anchor < ANCHOR_MIN || anchor > ANCHOR_MAX) {
-    return {
-      valid: false,
-      message: `Anchor BPM must be between ${ANCHOR_MIN} and ${ANCHOR_MAX}.`,
-    };
+  if (!isNumber(greenPct)) {
+    errors.green = 'Green deviation must be a number.';
+  } else if (!Number.isInteger(greenPct)) {
+    errors.green = 'Green deviation must be a whole number.';
   }
 
-  if (greenPct < GREEN_MIN || greenPct > GREEN_MAX) {
-    return {
-      valid: false,
-      message: `Green deviation must be between ${GREEN_MIN}% and ${GREEN_MAX}%.`,
-    };
+  if (!isNumber(yellowPct)) {
+    errors.yellow = 'Yellow deviation must be a number.';
+  } else if (!Number.isInteger(yellowPct)) {
+    errors.yellow = 'Yellow deviation must be a whole number.';
   }
 
-  if (yellowPct < YELLOW_MIN || yellowPct > YELLOW_MAX) {
-    return {
-      valid: false,
-      message: `Yellow deviation must be between ${YELLOW_MIN}% and ${YELLOW_MAX}%.`,
-    };
+  if (!errors.anchor) {
+    if (anchor < ANCHOR_MIN || anchor > ANCHOR_MAX) {
+      errors.anchor = `Anchor BPM must be between ${ANCHOR_MIN} and ${ANCHOR_MAX}.`;
+    }
   }
 
-  if (greenPct >= yellowPct) {
-    return { valid: false, message: 'Yellow deviation must be greater than green deviation.' };
+  if (!errors.green) {
+    if (greenPct < GREEN_MIN || greenPct > GREEN_MAX) {
+      errors.green = `Green deviation must be between ${GREEN_MIN}% and ${GREEN_MAX}%.`;
+    } else if (greenPct > PERCENTAGE_MAX) {
+      errors.green = 'Green deviation must be 100% or less.';
+    }
   }
 
-  if (greenPct > PERCENTAGE_MAX || yellowPct > PERCENTAGE_MAX) {
-    return { valid: false, message: 'Deviations must be 100% or less.' };
+  if (!errors.yellow) {
+    if (yellowPct < YELLOW_MIN || yellowPct > YELLOW_MAX) {
+      errors.yellow = `Yellow deviation must be between ${YELLOW_MIN}% and ${YELLOW_MAX}%.`;
+    } else if (yellowPct > PERCENTAGE_MAX) {
+      errors.yellow = 'Yellow deviation must be 100% or less.';
+    }
   }
 
-  return { valid: true };
+  if (!errors.green && !errors.yellow && greenPct >= yellowPct) {
+    errors.yellow = 'Yellow deviation must be greater than green deviation.';
+  }
+
+  const errorKeys = Object.keys(errors);
+
+  if (errorKeys.length > 0) {
+    const field = errorKeys[0];
+    return { valid: false, message: errors[field], field, errors };
+  }
+
+  return { valid: true, errors: {} };
 }
 
 function calculateDeviation(anchor, percentage) {

--- a/docs/assets/main.js
+++ b/docs/assets/main.js
@@ -13,8 +13,31 @@ import {
   formatThreshold,
   validateInputs,
 } from './calculation.js';
+import { buildAxisRows, buildAxisCsv } from './ui-logic.js';
 
 const STEP_ONE = 1;
+const QUICK_ANCHORS = [128, 130, 133, 136, 140];
+const PRESET_STORAGE_KEY = 'dj-bpm-zone-presets-v1';
+const FEEDBACK_CLEAR_DELAY = 3500;
+
+let quickAnchorButtons = [];
+let currentAxisRows = [];
+let currentMixingZones = null;
+let feedbackTimeoutId = null;
+let presets = [];
+
+const storageAvailable =
+  typeof window !== 'undefined' &&
+  (() => {
+    try {
+      const testKey = '__dj_bpm_storage_test__';
+      window.localStorage.setItem(testKey, '1');
+      window.localStorage.removeItem(testKey);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  })();
 
 function populateSelect(selectEl, min, max, step, unit, defaultValue) {
   selectEl.innerHTML = '';
@@ -22,37 +45,10 @@ function populateSelect(selectEl, min, max, step, unit, defaultValue) {
     const option = document.createElement('option');
     option.value = value;
     option.textContent = `${value}${unit}`;
-    option.className = 'bg-slate-800';
+    option.className = 'bg-slate-800 text-slate-100';
     selectEl.appendChild(option);
   }
   selectEl.value = String(defaultValue);
-}
-
-function renderError(errorMessageEl, resultsSectionEl, message) {
-  errorMessageEl.textContent = message;
-  resultsSectionEl.style.display = 'none';
-}
-
-function renderResults(results, elements, resultsSectionEl) {
-  const { green, yellow, red, anchor } = results;
-
-  elements.greenUpRange.textContent = formatBpm(green.up);
-  elements.greenDownRange.textContent = formatBpm(green.down);
-  elements.yellowUpRange.textContent = formatBpm(yellow.up);
-  elements.yellowDownRange.textContent = formatBpm(yellow.down);
-  elements.redUpThreshold.textContent = formatThreshold('<', red.upThreshold);
-  elements.redDownThreshold.textContent = formatThreshold('>', red.downThreshold);
-
-  elements.tableUpAnchor.textContent = formatBpm(anchor);
-  elements.tableUpGreen.textContent = formatBpm(green.up);
-  elements.tableUpYellow.textContent = formatBpm(yellow.up);
-  elements.tableUpRed.textContent = formatThreshold('<', red.upThreshold);
-  elements.tableDownAnchor.textContent = formatBpm(anchor);
-  elements.tableDownGreen.textContent = formatBpm(green.down);
-  elements.tableDownYellow.textContent = formatBpm(yellow.down);
-  elements.tableDownRed.textContent = formatThreshold('>', red.downThreshold);
-
-  resultsSectionEl.style.display = 'block';
 }
 
 function getElements() {
@@ -60,6 +56,14 @@ function getElements() {
     anchorSelect: document.getElementById('anchorBpm'),
     greenSelect: document.getElementById('greenDev'),
     yellowSelect: document.getElementById('yellowDev'),
+    fieldErrors: {
+      anchor: document.getElementById('anchor-error'),
+      green: document.getElementById('green-error'),
+      yellow: document.getElementById('yellow-error'),
+    },
+    quickAnchorsContainer: document.getElementById('quick-anchors'),
+    currentAnchorLabel: document.getElementById('current-anchor-label'),
+    settingsSummary: document.getElementById('settings-summary'),
     errorMessage: document.getElementById('error-message'),
     resultsSection: document.getElementById('results'),
     greenUpRange: document.getElementById('green-up-range'),
@@ -68,19 +72,634 @@ function getElements() {
     yellowDownRange: document.getElementById('yellow-down-range'),
     redUpThreshold: document.getElementById('red-up-threshold'),
     redDownThreshold: document.getElementById('red-down-threshold'),
-    tableUpAnchor: document.getElementById('table-up-anchor'),
-    tableUpGreen: document.getElementById('table-up-green'),
-    tableUpYellow: document.getElementById('table-up-yellow'),
-    tableUpRed: document.getElementById('table-up-red'),
-    tableDownAnchor: document.getElementById('table-down-anchor'),
-    tableDownGreen: document.getElementById('table-down-green'),
-    tableDownYellow: document.getElementById('table-down-yellow'),
-    tableDownRed: document.getElementById('table-down-red'),
+    copyFeedback: document.getElementById('feedback-message'),
+    axisBody: document.getElementById('axis-body'),
+    axisEmptyState: document.getElementById('axis-empty-state'),
+    copyAxisButton: document.getElementById('copy-axis-button'),
+    copyCsvButton: document.getElementById('copy-csv-button'),
+    downloadCsvButton: document.getElementById('download-csv-button'),
+    presetNameInput: document.getElementById('preset-name'),
+    savePresetButton: document.getElementById('save-preset'),
+    presetList: document.getElementById('preset-list'),
+    presetEmptyState: document.getElementById('preset-empty'),
+    presetsUnavailable: document.getElementById('presets-unavailable'),
+    resetButton: document.getElementById('reset-defaults'),
   };
+}
+
+function setFieldError(element, message) {
+  if (!element) {
+    return;
+  }
+  element.textContent = message || '';
+  element.style.visibility = message ? 'visible' : 'hidden';
+  element.setAttribute('aria-hidden', message ? 'false' : 'true');
+}
+
+function renderInlineErrors(errors, elements) {
+  const { fieldErrors, errorMessage } = elements;
+  if (!fieldErrors) {
+    return;
+  }
+
+  setFieldError(fieldErrors.anchor, errors?.anchor);
+  setFieldError(fieldErrors.green, errors?.green);
+  setFieldError(fieldErrors.yellow, errors?.yellow);
+
+  if (errorMessage) {
+    if (errors && Object.keys(errors).length > 0) {
+      errorMessage.textContent = Object.values(errors)[0];
+    } else {
+      errorMessage.textContent = '';
+    }
+  }
+}
+
+function toggleResultsVisibility(elements, show) {
+  if (!elements.resultsSection) {
+    return;
+  }
+  if (show) {
+    elements.resultsSection.classList.remove('hidden');
+    elements.resultsSection.setAttribute('aria-hidden', 'false');
+  } else {
+    elements.resultsSection.classList.add('hidden');
+    elements.resultsSection.setAttribute('aria-hidden', 'true');
+  }
+}
+
+function renderResultsCards(results, elements, selection) {
+  const { anchor, green, yellow, red } = results;
+
+  if (elements.greenUpRange) {
+    elements.greenUpRange.textContent = formatBpm(green.up);
+  }
+  if (elements.greenDownRange) {
+    elements.greenDownRange.textContent = formatBpm(green.down);
+  }
+  if (elements.yellowUpRange) {
+    elements.yellowUpRange.textContent = formatBpm(yellow.up);
+  }
+  if (elements.yellowDownRange) {
+    elements.yellowDownRange.textContent = formatBpm(yellow.down);
+  }
+  if (elements.redUpThreshold) {
+    elements.redUpThreshold.textContent = formatThreshold('<', red.upThreshold);
+  }
+  if (elements.redDownThreshold) {
+    elements.redDownThreshold.textContent = formatThreshold('>', red.downThreshold);
+  }
+  if (elements.currentAnchorLabel) {
+    elements.currentAnchorLabel.textContent = formatBpm(anchor);
+  }
+  if (elements.settingsSummary && selection) {
+    const summaryParts = [
+      `Anchor ${formatBpm(anchor)}`,
+      `Green ±${selection.greenPct}%`,
+      `Yellow ±${selection.yellowPct}%`,
+    ];
+    elements.settingsSummary.textContent = summaryParts.join(' • ');
+  }
+}
+
+function updateQuickAnchorSelection(anchorValue) {
+  quickAnchorButtons.forEach((button) => {
+    const isActive = Number(button.dataset.anchor) === anchorValue;
+    button.classList.toggle('bg-teal-600/80', isActive);
+    button.classList.toggle('border-teal-400/80', isActive);
+    button.classList.toggle('text-teal-50', isActive);
+    button.classList.toggle('bg-slate-800/60', !isActive);
+    button.classList.toggle('border-slate-700/70', !isActive);
+    button.classList.toggle('text-slate-200', !isActive);
+    button.setAttribute('aria-pressed', String(isActive));
+  });
+}
+
+function renderAxis(rows, elements) {
+  const { axisBody, axisEmptyState, copyAxisButton, copyCsvButton, downloadCsvButton } = elements;
+  if (!axisBody) {
+    return;
+  }
+
+  axisBody.innerHTML = '';
+
+  if (!rows.length) {
+    if (axisEmptyState) {
+      axisEmptyState.classList.remove('hidden');
+    }
+    if (copyAxisButton) {
+      copyAxisButton.disabled = true;
+    }
+    if (copyCsvButton) {
+      copyCsvButton.disabled = true;
+    }
+    if (downloadCsvButton) {
+      downloadCsvButton.disabled = true;
+    }
+    return;
+  }
+
+  if (axisEmptyState) {
+    axisEmptyState.classList.add('hidden');
+  }
+
+  const fragment = document.createDocumentFragment();
+
+  rows.forEach((row) => {
+    const tr = document.createElement('tr');
+    tr.className = 'hover:bg-slate-800/40 transition-colors';
+
+    const directionCell = document.createElement('td');
+    directionCell.className = 'px-4 py-3 font-semibold uppercase text-xs tracking-wide text-slate-300';
+    directionCell.textContent = row.direction;
+    tr.appendChild(directionCell);
+
+    const zoneCell = document.createElement('td');
+    zoneCell.className = 'px-4 py-3 font-medium';
+    zoneCell.textContent = row.zone;
+    if (row.zone.includes('Anchor')) {
+      zoneCell.classList.add('text-teal-200');
+    } else if (row.zone === 'Green') {
+      zoneCell.classList.add('text-green-300');
+    } else if (row.zone === 'Yellow') {
+      zoneCell.classList.add('text-amber-300');
+    } else if (row.zone === 'Red') {
+      zoneCell.classList.add('text-red-300');
+    }
+    tr.appendChild(zoneCell);
+
+    const minCell = document.createElement('td');
+    minCell.className = 'px-4 py-3 text-slate-200';
+    minCell.textContent = row.minLabel;
+    tr.appendChild(minCell);
+
+    const maxCell = document.createElement('td');
+    maxCell.className = 'px-4 py-3 text-slate-200';
+    maxCell.textContent = row.maxLabel;
+    tr.appendChild(maxCell);
+
+    const notesCell = document.createElement('td');
+    notesCell.className = 'px-4 py-3 text-sm text-slate-300';
+    notesCell.textContent = row.description;
+    tr.appendChild(notesCell);
+
+    const copyCell = document.createElement('td');
+    copyCell.className = 'px-4 py-3 text-center';
+    const copyButton = document.createElement('button');
+    copyButton.type = 'button';
+    copyButton.dataset.copyText = row.copyText;
+    copyButton.dataset.copyLabel = `${row.direction} ${row.zone}`;
+    copyButton.className =
+      'inline-flex items-center justify-center gap-2 rounded-md border px-3 py-1.5 text-xs sm:text-sm transition-colors ' +
+      'bg-slate-900/70 border-slate-700/80 text-slate-200 hover:bg-teal-700/80 hover:text-white hover:border-teal-500/70 ' +
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900';
+    copyButton.textContent = 'Copy';
+    copyCell.appendChild(copyButton);
+    tr.appendChild(copyCell);
+
+    fragment.appendChild(tr);
+  });
+
+  axisBody.appendChild(fragment);
+
+  if (copyAxisButton) {
+    copyAxisButton.disabled = false;
+  }
+  if (copyCsvButton) {
+    copyCsvButton.disabled = false;
+  }
+  if (downloadCsvButton) {
+    downloadCsvButton.disabled = false;
+  }
+}
+
+function clearFeedback(elements) {
+  if (!elements.copyFeedback) {
+    return;
+  }
+  elements.copyFeedback.textContent = '';
+  elements.copyFeedback.classList.remove('text-teal-300', 'text-rose-300', 'text-slate-200');
+}
+
+function showFeedback(elements, message, tone = 'info') {
+  if (!elements.copyFeedback) {
+    return;
+  }
+
+  clearTimeout(feedbackTimeoutId);
+  clearFeedback(elements);
+
+  const toneClass = tone === 'success' ? 'text-teal-300' : tone === 'error' ? 'text-rose-300' : 'text-slate-200';
+  elements.copyFeedback.classList.add(toneClass);
+  elements.copyFeedback.textContent = message;
+
+  feedbackTimeoutId = window.setTimeout(() => {
+    clearFeedback(elements);
+  }, FEEDBACK_CLEAR_DELAY);
+}
+
+async function copyToClipboard(text) {
+  if (!text) {
+    return false;
+  }
+
+  try {
+    if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch (error) {
+    // Fall back to legacy approach below.
+  }
+
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.setAttribute('readonly', '');
+  textArea.style.position = 'absolute';
+  textArea.style.left = '-9999px';
+  document.body.appendChild(textArea);
+  textArea.select();
+
+  let success = false;
+  try {
+    success = document.execCommand('copy');
+  } catch (error) {
+    success = false;
+  }
+
+  document.body.removeChild(textArea);
+  return success;
+}
+
+function handleAxisCopyClick(event, elements) {
+  const button = event.target.closest('button[data-copy-text]');
+  if (!button) {
+    return;
+  }
+
+  const { copyText, copyLabel } = button.dataset;
+  if (!copyText) {
+    showFeedback(elements, 'Nothing to copy for this row.', 'error');
+    return;
+  }
+
+  copyToClipboard(copyText).then((success) => {
+    if (success) {
+      showFeedback(elements, `${copyLabel || 'Range'} copied to clipboard.`, 'success');
+    } else {
+      showFeedback(elements, 'Unable to copy to clipboard.', 'error');
+    }
+  });
+}
+
+function handleCopySummary(elements) {
+  if (!currentAxisRows.length) {
+    showFeedback(elements, 'Generate axis ranges before copying.', 'error');
+    return;
+  }
+  const summary = currentAxisRows.map((row) => row.copyText).join('\n');
+  copyToClipboard(summary).then((success) => {
+    if (success) {
+      showFeedback(elements, 'Axis summary copied to clipboard.', 'success');
+    } else {
+      showFeedback(elements, 'Unable to copy axis summary.', 'error');
+    }
+  });
+}
+
+function handleCopyCsv(elements) {
+  if (!currentAxisRows.length || !currentMixingZones) {
+    showFeedback(elements, 'Generate axis ranges before copying CSV.', 'error');
+    return;
+  }
+
+  const csv = buildAxisCsv(currentAxisRows, currentMixingZones.anchor);
+  copyToClipboard(csv).then((success) => {
+    if (success) {
+      showFeedback(elements, 'Rekordbox CSV copied to clipboard.', 'success');
+    } else {
+      showFeedback(elements, 'Unable to copy CSV.', 'error');
+    }
+  });
+}
+
+function handleDownloadCsv(elements) {
+  if (!currentAxisRows.length || !currentMixingZones) {
+    showFeedback(elements, 'Generate axis ranges before downloading CSV.', 'error');
+    return;
+  }
+
+  const csv = buildAxisCsv(currentAxisRows, currentMixingZones.anchor);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `dj-bpm-axis-${currentMixingZones.anchor}bpm.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+  showFeedback(elements, 'CSV download started.', 'success');
+}
+
+function createPresetId() {
+  return `preset-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function sanitizePreset(preset) {
+  if (!preset || typeof preset !== 'object') {
+    return null;
+  }
+  if (typeof preset.name !== 'string') {
+    return null;
+  }
+  const name = preset.name.trim();
+  if (!name) {
+    return null;
+  }
+  const anchor = Number(preset.anchor);
+  const green = Number(preset.green);
+  const yellow = Number(preset.yellow);
+  if (!Number.isInteger(anchor) || !Number.isInteger(green) || !Number.isInteger(yellow)) {
+    return null;
+  }
+  const validation = validateInputs(anchor, green, yellow);
+  if (!validation.valid) {
+    return null;
+  }
+  return {
+    id: typeof preset.id === 'string' ? preset.id : createPresetId(),
+    name,
+    anchor,
+    green,
+    yellow,
+    savedAt: typeof preset.savedAt === 'string' ? preset.savedAt : new Date().toISOString(),
+  };
+}
+
+function loadPresets() {
+  if (!storageAvailable) {
+    return [];
+  }
+  try {
+    const raw = window.localStorage.getItem(PRESET_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .map((preset) => sanitizePreset(preset))
+      .filter((preset) => preset !== null);
+  } catch (error) {
+    console.warn('Failed to load presets from storage', error);
+    return [];
+  }
+}
+
+function persistPresets() {
+  if (!storageAvailable) {
+    return false;
+  }
+  try {
+    window.localStorage.setItem(PRESET_STORAGE_KEY, JSON.stringify(presets));
+    return true;
+  } catch (error) {
+    console.warn('Failed to persist presets', error);
+    return false;
+  }
+}
+
+function renderPresetList(elements) {
+  const { presetList, presetEmptyState } = elements;
+  if (!presetList) {
+    return;
+  }
+
+  presetList.innerHTML = '';
+
+  if (!presets.length) {
+    if (presetEmptyState) {
+      presetEmptyState.classList.remove('hidden');
+    }
+    return;
+  }
+
+  if (presetEmptyState) {
+    presetEmptyState.classList.add('hidden');
+  }
+
+  const sorted = [...presets].sort((a, b) => {
+    const aTime = new Date(a.savedAt).getTime();
+    const bTime = new Date(b.savedAt).getTime();
+    return bTime - aTime;
+  });
+
+  const fragment = document.createDocumentFragment();
+  sorted.forEach((preset) => {
+    const listItem = document.createElement('li');
+    listItem.className =
+      'flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between rounded-lg border border-slate-700/60 bg-slate-900/60 p-4';
+
+    const infoWrapper = document.createElement('div');
+    const nameEl = document.createElement('p');
+    nameEl.className = 'text-sm font-semibold text-slate-100';
+    nameEl.textContent = preset.name;
+    const detailEl = document.createElement('p');
+    detailEl.className = 'text-xs text-slate-400';
+    detailEl.textContent = `A${preset.anchor} • G±${preset.green}% • Y±${preset.yellow}%`;
+    infoWrapper.appendChild(nameEl);
+    infoWrapper.appendChild(detailEl);
+
+    const actions = document.createElement('div');
+    actions.className = 'flex flex-wrap gap-2';
+
+    const loadButton = document.createElement('button');
+    loadButton.type = 'button';
+    loadButton.dataset.action = 'load';
+    loadButton.dataset.presetId = preset.id;
+    loadButton.className =
+      'px-3 py-1.5 text-xs sm:text-sm rounded-md bg-teal-700/80 text-white border border-teal-500/60 hover:bg-teal-600/80 ' +
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900';
+    loadButton.textContent = 'Load';
+
+    const deleteButton = document.createElement('button');
+    deleteButton.type = 'button';
+    deleteButton.dataset.action = 'delete';
+    deleteButton.dataset.presetId = preset.id;
+    deleteButton.className =
+      'px-3 py-1.5 text-xs sm:text-sm rounded-md border border-slate-600/70 text-slate-200 hover:bg-slate-800/70 hover:text-white ' +
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900';
+    deleteButton.textContent = 'Delete';
+
+    actions.appendChild(loadButton);
+    actions.appendChild(deleteButton);
+
+    listItem.appendChild(infoWrapper);
+    listItem.appendChild(actions);
+
+    fragment.appendChild(listItem);
+  });
+
+  presetList.appendChild(fragment);
+}
+
+function handleSavePreset(elements) {
+  if (!storageAvailable) {
+    showFeedback(elements, 'Browser storage is unavailable. Presets are disabled.', 'error');
+    return;
+  }
+
+  const name = elements.presetNameInput?.value.trim();
+  if (!name) {
+    showFeedback(elements, 'Enter a name before saving a preset.', 'error');
+    if (elements.presetNameInput) {
+      elements.presetNameInput.focus();
+    }
+    return;
+  }
+
+  const anchor = Number(elements.anchorSelect.value);
+  const greenPct = Number(elements.greenSelect.value);
+  const yellowPct = Number(elements.yellowSelect.value);
+  const validation = validateInputs(anchor, greenPct, yellowPct);
+  if (!validation.valid) {
+    showFeedback(elements, `Cannot save preset: ${validation.message}`, 'error');
+    return;
+  }
+
+  const existingIndex = presets.findIndex((preset) => preset.name.toLowerCase() === name.toLowerCase());
+  const presetData = {
+    id: existingIndex >= 0 ? presets[existingIndex].id : createPresetId(),
+    name,
+    anchor,
+    green: greenPct,
+    yellow: yellowPct,
+    savedAt: new Date().toISOString(),
+  };
+
+  if (existingIndex >= 0) {
+    presets[existingIndex] = presetData;
+  } else {
+    presets.push(presetData);
+  }
+
+  if (!persistPresets()) {
+    showFeedback(elements, 'Unable to save preset to browser storage.', 'error');
+    return;
+  }
+
+  renderPresetList(elements);
+  showFeedback(elements, `Preset “${name}” saved.`, 'success');
+}
+
+function applyPreset(preset, elements, handleChange) {
+  if (!preset) {
+    return;
+  }
+  elements.anchorSelect.value = String(preset.anchor);
+  elements.greenSelect.value = String(preset.green);
+  elements.yellowSelect.value = String(preset.yellow);
+  handleChange();
+  elements.anchorSelect.focus({ preventScroll: true });
+}
+
+function handlePresetListAction(event, elements, handleChange) {
+  const button = event.target.closest('button[data-action][data-preset-id]');
+  if (!button) {
+    return;
+  }
+
+  const { action, presetId } = button.dataset;
+  const preset = presets.find((item) => item.id === presetId);
+
+  if (action === 'load' && preset) {
+    applyPreset(preset, elements, handleChange);
+    showFeedback(elements, `Preset “${preset.name}” loaded.`, 'success');
+    if (elements.presetNameInput) {
+      elements.presetNameInput.value = preset.name;
+    }
+  } else if (action === 'delete' && preset) {
+    presets = presets.filter((item) => item.id !== presetId);
+    if (!persistPresets()) {
+      showFeedback(elements, 'Unable to update presets in storage.', 'error');
+      return;
+    }
+    renderPresetList(elements);
+    showFeedback(elements, 'Preset deleted.', 'info');
+  }
+}
+
+function resetToDefaults(elements, handleChange) {
+  elements.anchorSelect.value = String(DEFAULT_ANCHOR);
+  elements.greenSelect.value = String(DEFAULT_GREEN_DEV);
+  elements.yellowSelect.value = String(DEFAULT_YELLOW_DEV);
+  handleChange();
+  elements.anchorSelect.focus({ preventScroll: true });
+}
+
+function initQuickAnchors(elements, handleChange) {
+  const container = elements.quickAnchorsContainer;
+  if (!container) {
+    return;
+  }
+
+  container.innerHTML = '';
+  quickAnchorButtons = [];
+
+  QUICK_ANCHORS.forEach((anchorValue) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.dataset.anchor = String(anchorValue);
+    button.className =
+      'px-3 py-1.5 text-xs sm:text-sm rounded-md border bg-slate-800/60 border-slate-700/70 text-slate-200 transition-colors ' +
+      'hover:bg-teal-600/80 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 ' +
+      'focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900';
+    button.textContent = `${anchorValue} BPM`;
+    button.setAttribute('aria-pressed', 'false');
+    button.addEventListener('click', () => {
+      elements.anchorSelect.value = String(anchorValue);
+      handleChange();
+    });
+    quickAnchorButtons.push(button);
+    container.appendChild(button);
+  });
+}
+
+function initPresetsSection(elements, handleChange) {
+  if (!elements.presetNameInput || !elements.savePresetButton || !elements.presetList) {
+    return;
+  }
+
+  if (!storageAvailable) {
+    elements.presetNameInput.disabled = true;
+    elements.savePresetButton.disabled = true;
+    if (elements.presetsUnavailable) {
+      elements.presetsUnavailable.classList.remove('hidden');
+    }
+    return;
+  }
+
+  presets = loadPresets();
+  renderPresetList(elements);
+
+  elements.savePresetButton.addEventListener('click', () => handleSavePreset(elements));
+  elements.presetNameInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleSavePreset(elements);
+    }
+  });
+  elements.presetList.addEventListener('click', (event) => handlePresetListAction(event, elements, handleChange));
 }
 
 function init() {
   const elements = getElements();
+  if (!elements.anchorSelect || !elements.greenSelect || !elements.yellowSelect) {
+    return;
+  }
 
   populateSelect(
     elements.anchorSelect,
@@ -109,28 +728,66 @@ function init() {
 
   const handleChange = () => {
     const anchor = Number(elements.anchorSelect.value);
-    const green = Number(elements.greenSelect.value);
-    const yellow = Number(elements.yellowSelect.value);
+    const greenPct = Number(elements.greenSelect.value);
+    const yellowPct = Number(elements.yellowSelect.value);
 
-    const validation = validateInputs(anchor, green, yellow);
+    clearFeedback(elements);
+
+    const validation = validateInputs(anchor, greenPct, yellowPct);
+    renderInlineErrors(validation.errors, elements);
 
     if (!validation.valid) {
-      renderError(elements.errorMessage, elements.resultsSection, validation.message);
+      toggleResultsVisibility(elements, false);
+      if (elements.currentAnchorLabel) {
+        elements.currentAnchorLabel.textContent = '—';
+      }
+      if (elements.settingsSummary) {
+        elements.settingsSummary.textContent = '';
+      }
+      currentAxisRows = [];
+      currentMixingZones = null;
+      renderAxis([], elements);
       return;
     }
 
-    elements.errorMessage.textContent = '';
-
-    const results = calculateMixingZones(anchor, green, yellow);
-    renderResults(results, elements, elements.resultsSection);
+    const results = calculateMixingZones(anchor, greenPct, yellowPct);
+    currentMixingZones = results;
+    currentAxisRows = buildAxisRows(results);
+    renderResultsCards(results, elements, { anchor, greenPct, yellowPct });
+    renderAxis(currentAxisRows, elements);
+    toggleResultsVisibility(elements, true);
+    updateQuickAnchorSelection(anchor);
   };
 
-  [elements.anchorSelect, elements.greenSelect, elements.yellowSelect].forEach((select) => {
-    select.addEventListener('change', handleChange);
-  });
+  initQuickAnchors(elements, handleChange);
+  initPresetsSection(elements, handleChange);
+
+  elements.anchorSelect.addEventListener('change', handleChange);
+  elements.greenSelect.addEventListener('change', handleChange);
+  elements.yellowSelect.addEventListener('change', handleChange);
+
+  if (elements.resetButton) {
+    elements.resetButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      resetToDefaults(elements, handleChange);
+      showFeedback(elements, 'Settings reset to defaults.', 'info');
+    });
+  }
+
+  if (elements.axisBody) {
+    elements.axisBody.addEventListener('click', (event) => handleAxisCopyClick(event, elements));
+  }
+  if (elements.copyAxisButton) {
+    elements.copyAxisButton.addEventListener('click', () => handleCopySummary(elements));
+  }
+  if (elements.copyCsvButton) {
+    elements.copyCsvButton.addEventListener('click', () => handleCopyCsv(elements));
+  }
+  if (elements.downloadCsvButton) {
+    elements.downloadCsvButton.addEventListener('click', () => handleDownloadCsv(elements));
+  }
 
   handleChange();
 }
 
 document.addEventListener('DOMContentLoaded', init);
-

--- a/docs/assets/ui-logic.js
+++ b/docs/assets/ui-logic.js
@@ -1,0 +1,231 @@
+import { formatBpm } from './calculation.js';
+
+const RANGE_TYPES = {
+  RANGE: 'range',
+  MAX: 'max',
+  MIN: 'min',
+  ANCHOR: 'anchor',
+};
+
+const ZONE_DESCRIPTIONS = {
+  up: {
+    Green: 'Optimal mix window (slower track)',
+    Yellow: 'Stretch / caution (slower track)',
+    Red: 'Out of range — too slow',
+  },
+  down: {
+    Green: 'Optimal mix window (faster track)',
+    Yellow: 'Stretch / caution (faster track)',
+    Red: 'Out of range — too fast',
+  },
+  anchor: 'Reference anchor tempo',
+};
+
+function clampRange(min, max) {
+  if (typeof min === 'number' && typeof max === 'number' && max < min) {
+    return { min, max: min };
+  }
+  return { min, max };
+}
+
+function formatRangeLabels(rangeType, minValue, maxValue) {
+  if (rangeType === RANGE_TYPES.RANGE) {
+    return {
+      minLabel: formatBpm(minValue),
+      maxLabel: formatBpm(maxValue),
+      rangeText: `${formatBpm(minValue)} – ${formatBpm(maxValue)}`,
+    };
+  }
+
+  if (rangeType === RANGE_TYPES.MAX) {
+    return {
+      minLabel: '—',
+      maxLabel: `≤ ${formatBpm(maxValue)}`,
+      rangeText: `≤ ${formatBpm(maxValue)}`,
+    };
+  }
+
+  if (rangeType === RANGE_TYPES.MIN) {
+    return {
+      minLabel: `≥ ${formatBpm(minValue)}`,
+      maxLabel: '—',
+      rangeText: `≥ ${formatBpm(minValue)}`,
+    };
+  }
+
+  return {
+    minLabel: formatBpm(minValue),
+    maxLabel: formatBpm(maxValue),
+    rangeText: formatBpm(minValue),
+  };
+}
+
+function buildRow({
+  id,
+  direction,
+  zone,
+  description,
+  rangeType,
+  minValue,
+  maxValue,
+  csvNote,
+}) {
+  const { min, max } = clampRange(minValue, maxValue);
+  const labels = formatRangeLabels(rangeType, min, max);
+  const copyText =
+    rangeType === RANGE_TYPES.ANCHOR
+      ? `${zone}: ${labels.rangeText}`
+      : `${direction} • ${zone}: ${labels.rangeText}`;
+
+  return {
+    id,
+    direction,
+    zone,
+    description,
+    rangeType,
+    minValue: min,
+    maxValue: max,
+    minLabel: labels.minLabel,
+    maxLabel: labels.maxLabel,
+    rangeText: labels.rangeText,
+    copyText,
+    csv: {
+      min: typeof min === 'number' ? String(min) : '',
+      max: typeof max === 'number' ? String(max) : '',
+      note: csvNote ?? description,
+    },
+  };
+}
+
+export function buildAxisRows(mixingZones) {
+  const { anchor, green, yellow } = mixingZones;
+
+  const anchorMinusOne = anchor - 1;
+  const anchorPlusOne = anchor + 1;
+
+  const upGreenMax = Math.max(green.up, anchorMinusOne);
+  const upYellowMax = Math.max(yellow.up, upGreenMax - 1);
+  const downGreenMin = Math.min(green.down, anchorPlusOne);
+  const downYellowMinCandidate = green.down + 1;
+  const downYellowMin = downYellowMinCandidate <= yellow.down ? downYellowMinCandidate : yellow.down;
+
+  const rows = [];
+
+  rows.push(
+    buildRow({
+      id: 'up-green',
+      direction: 'Upmix',
+      zone: 'Green',
+      description: ZONE_DESCRIPTIONS.up.Green,
+      rangeType: RANGE_TYPES.RANGE,
+      minValue: green.up,
+      maxValue: upGreenMax,
+    }),
+  );
+
+  rows.push(
+    buildRow({
+      id: 'up-yellow',
+      direction: 'Upmix',
+      zone: 'Yellow',
+      description: ZONE_DESCRIPTIONS.up.Yellow,
+      rangeType: RANGE_TYPES.RANGE,
+      minValue: yellow.up,
+      maxValue: upYellowMax,
+    }),
+  );
+
+  rows.push(
+    buildRow({
+      id: 'up-red',
+      direction: 'Upmix',
+      zone: 'Red',
+      description: ZONE_DESCRIPTIONS.up.Red,
+      rangeType: RANGE_TYPES.MAX,
+      minValue: null,
+      maxValue: yellow.up - 1,
+      csvNote: `${ZONE_DESCRIPTIONS.up.Red} (≤ ${formatBpm(yellow.up - 1)})`,
+    }),
+  );
+
+  rows.push(
+    buildRow({
+      id: 'anchor',
+      direction: 'Anchor',
+      zone: 'Anchor BPM',
+      description: ZONE_DESCRIPTIONS.anchor,
+      rangeType: RANGE_TYPES.ANCHOR,
+      minValue: anchor,
+      maxValue: anchor,
+    }),
+  );
+
+  rows.push(
+    buildRow({
+      id: 'down-green',
+      direction: 'Downmix',
+      zone: 'Green',
+      description: ZONE_DESCRIPTIONS.down.Green,
+      rangeType: RANGE_TYPES.RANGE,
+      minValue: downGreenMin,
+      maxValue: green.down,
+    }),
+  );
+
+  rows.push(
+    buildRow({
+      id: 'down-yellow',
+      direction: 'Downmix',
+      zone: 'Yellow',
+      description: ZONE_DESCRIPTIONS.down.Yellow,
+      rangeType: RANGE_TYPES.RANGE,
+      minValue: downYellowMin,
+      maxValue: yellow.down,
+    }),
+  );
+
+  rows.push(
+    buildRow({
+      id: 'down-red',
+      direction: 'Downmix',
+      zone: 'Red',
+      description: ZONE_DESCRIPTIONS.down.Red,
+      rangeType: RANGE_TYPES.MIN,
+      minValue: yellow.down + 1,
+      maxValue: null,
+      csvNote: `${ZONE_DESCRIPTIONS.down.Red} (≥ ${formatBpm(yellow.down + 1)})`,
+    }),
+  );
+
+  return rows;
+}
+
+function escapeCsvValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const stringValue = String(value);
+  if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+  return stringValue;
+}
+
+export function buildAxisCsv(rows, anchor) {
+  const lines = [
+    ['Direction', 'Zone', 'Min BPM', 'Max BPM', 'Anchor BPM', 'Notes'],
+    ...rows.map((row) => [
+      row.direction,
+      row.zone,
+      row.csv.min,
+      row.csv.max,
+      String(anchor),
+      row.csv.note,
+    ]),
+  ];
+
+  return lines.map((line) => line.map(escapeCsvValue).join(',')).join('\r\n');
+}
+
+export const RANGE_TYPE = RANGE_TYPES;

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,7 +48,7 @@
 
     <div class="min-h-screen bg-gradient-to-br from-slate-900 to-teal-950 text-slate-200 p-4 sm:p-6 lg:p-8">
       <main class="max-w-7xl mx-auto bg-slate-900/60 backdrop-blur-sm rounded-2xl shadow-2xl border border-teal-800/50 overflow-hidden">
-        
+
         <header class="bg-gradient-to-r from-slate-900 to-teal-950 text-white p-6 sm:p-8 text-center rounded-t-2xl">
           <h1 class="text-3xl sm:text-4xl font-bold text-slate-100 drop-shadow-lg">DJ BPM Zone Calculator</h1>
           <p class="mt-2 text-base sm:text-lg text-slate-300">Calculate optimal mixing zones based on groove analysis</p>
@@ -61,122 +61,160 @@
 
         <section class="p-6 sm:p-8">
           <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-            
-            <div class="flex flex-col">
-              <label for="anchorBpm" class="mb-2 font-semibold text-slate-300 text-sm">Anchor BPM (A)</label>
+
+            <div class="flex flex-col gap-3">
+              <label for="anchorBpm" class="font-semibold text-slate-300 text-sm">Anchor BPM (A)</label>
               <div class="relative">
                 <select id="anchorBpm" class="w-full px-4 py-3 bg-slate-800/50 border-2 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-teal-500 transition-colors duration-300 border-slate-700"></select>
                 <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-slate-400">
                   <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
                 </div>
               </div>
+              <p id="anchor-error" class="text-xs text-rose-300 min-h-[1.25rem]" style="visibility: hidden;" aria-live="polite" aria-hidden="true"></p>
+              <div id="quick-anchors" class="flex flex-wrap gap-2" role="group" aria-label="Quick anchors"></div>
             </div>
 
-            <div class="flex flex-col">
-              <label for="greenDev" class="mb-2 font-semibold text-slate-300 text-sm">Green Max Deviation (%)</label>
+            <div class="flex flex-col gap-3">
+              <label for="greenDev" class="font-semibold text-slate-300 text-sm">Green Max Deviation (%)</label>
               <div class="relative">
                   <select id="greenDev" class="w-full px-4 py-3 bg-slate-800/50 border-2 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-teal-500 transition-colors duration-300 border-slate-700"></select>
                   <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-slate-400">
                     <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
                   </div>
               </div>
+              <p id="green-error" class="text-xs text-rose-300 min-h-[1.25rem]" style="visibility: hidden;" aria-live="polite" aria-hidden="true"></p>
             </div>
 
-            <div class="flex flex-col">
-              <label for="yellowDev" class="mb-2 font-semibold text-slate-300 text-sm">Yellow Max Deviation (%)</label>
+            <div class="flex flex-col gap-3">
+              <label for="yellowDev" class="font-semibold text-slate-300 text-sm">Yellow Max Deviation (%)</label>
               <div class="relative">
                   <select id="yellowDev" class="w-full px-4 py-3 bg-slate-800/50 border-2 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-teal-500 transition-colors duration-300 border-slate-700"></select>
                   <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-slate-400">
                     <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
                   </div>
               </div>
+              <p id="yellow-error" class="text-xs text-rose-300 min-h-[1.25rem]" style="visibility: hidden;" aria-live="polite" aria-hidden="true"></p>
             </div>
-            
+
           </div>
 
-          <p id="error-message" class="mt-4 text-center text-red-400"></p>
+          <div class="mt-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div class="flex flex-col gap-1 text-sm text-slate-300 sm:flex-row sm:items-center sm:gap-2">
+              <span>Current anchor:</span>
+              <span id="current-anchor-label" class="text-lg font-semibold text-teal-300">—</span>
+            </div>
+            <button id="reset-defaults" type="button" class="inline-flex items-center gap-2 self-start rounded-md border border-slate-600/70 bg-slate-800/60 px-4 py-2 text-sm text-slate-200 transition-colors hover:bg-slate-700/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 sm:self-auto">
+              Reset to defaults
+            </button>
+          </div>
+
+          <p id="settings-summary" class="mt-3 text-center text-sm text-slate-400 sm:text-left"></p>
+          <p id="error-message" class="mt-4 text-center text-sm text-rose-300" aria-live="assertive"></p>
         </section>
-        
-        <section class="p-6 sm:p-8 pt-0" id="results" style="display: none;">
-            <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-              <!-- Green Zone Card -->
-              <div class="bg-slate-800/70 p-6 rounded-lg border-l-4 border-green-500 shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300">
-                <h3 class="text-xl font-bold text-white mb-4">Green Zone (Optimal Mix)</h3>
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <div class="text-center bg-slate-700/50 p-4 rounded-md">
-                    <div class="text-sm text-slate-400 mb-1">Upmix Range</div>
+
+        <section class="px-6 sm:px-8 pb-6">
+          <div class="space-y-4 rounded-xl border border-slate-700/60 bg-slate-900/60 p-5">
+            <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <h2 class="text-lg font-semibold text-slate-100">Presets</h2>
+                <p class="text-sm text-slate-400">Save and recall anchor & deviation combos for different sets.</p>
+              </div>
+              <div class="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-end">
+                <label class="flex w-full flex-col gap-2 text-sm text-slate-300 sm:w-64">
+                  <span class="font-medium">Preset name</span>
+                  <input id="preset-name" type="text" placeholder="e.g., Warm-up set" class="w-full rounded-md border border-slate-700/70 bg-slate-800/70 px-3 py-2 text-slate-100 placeholder:text-slate-500 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500" />
+                </label>
+                <button id="save-preset" type="button" class="inline-flex items-center justify-center rounded-md border border-teal-500/60 bg-teal-700/80 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-teal-600/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900">
+                  Save preset
+                </button>
+              </div>
+            </div>
+            <p id="presets-unavailable" class="text-sm text-amber-300 hidden">Presets require browser storage, which is unavailable in this session.</p>
+            <ul id="preset-list" class="flex flex-col gap-3"></ul>
+            <p id="preset-empty" class="text-sm text-slate-400 italic">No presets saved yet.</p>
+          </div>
+        </section>
+
+        <section class="hidden p-6 sm:p-8 pt-0" id="results" aria-hidden="true">
+            <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+              <div class="rounded-lg border-l-4 border-green-500 bg-slate-800/70 p-6 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl">
+                <h3 class="text-xl font-bold text-white">Green Zone (Optimal Mix)</h3>
+                <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div class="rounded-md bg-slate-700/50 p-4 text-center">
+                    <div class="text-sm text-slate-400">Upmix Range</div>
                     <div id="green-up-range" class="text-2xl font-bold text-white">-</div>
                   </div>
-                  <div class="text-center bg-slate-700/50 p-4 rounded-md">
-                    <div class="text-sm text-slate-400 mb-1">Downmix Range</div>
+                  <div class="rounded-md bg-slate-700/50 p-4 text-center">
+                    <div class="text-sm text-slate-400">Downmix Range</div>
                     <div id="green-down-range" class="text-2xl font-bold text-white">-</div>
                   </div>
                 </div>
               </div>
-              <!-- Yellow Zone Card -->
-              <div class="bg-slate-800/70 p-6 rounded-lg border-l-4 border-yellow-500 shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300">
-                <h3 class="text-xl font-bold text-white mb-4">Yellow Zone (Caution Mix)</h3>
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <div class="text-center bg-slate-700/50 p-4 rounded-md">
-                    <div class="text-sm text-slate-400 mb-1">Upmix Range</div>
+              <div class="rounded-lg border-l-4 border-yellow-500 bg-slate-800/70 p-6 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl">
+                <h3 class="text-xl font-bold text-white">Yellow Zone (Caution Mix)</h3>
+                <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div class="rounded-md bg-slate-700/50 p-4 text-center">
+                    <div class="text-sm text-slate-400">Upmix Range</div>
                     <div id="yellow-up-range" class="text-2xl font-bold text-white">-</div>
                   </div>
-                  <div class="text-center bg-slate-700/50 p-4 rounded-md">
-                    <div class="text-sm text-slate-400 mb-1">Downmix Range</div>
+                  <div class="rounded-md bg-slate-700/50 p-4 text-center">
+                    <div class="text-sm text-slate-400">Downmix Range</div>
                     <div id="yellow-down-range" class="text-2xl font-bold text-white">-</div>
                   </div>
                 </div>
               </div>
-              <!-- Red Zone Card -->
-              <div class="bg-slate-800/70 p-6 rounded-lg border-l-4 border-red-500 shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300">
-                <h3 class="text-xl font-bold text-white mb-4">Red Zone (Avoid Mix)</h3>
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <div class="text-center bg-slate-700/50 p-4 rounded-md">
-                    <div class="text-sm text-slate-400 mb-1">Upmix Threshold</div>
+              <div class="rounded-lg border-l-4 border-red-500 bg-slate-800/70 p-6 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl">
+                <h3 class="text-xl font-bold text-white">Red Zone (Avoid Mix)</h3>
+                <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div class="rounded-md bg-slate-700/50 p-4 text-center">
+                    <div class="text-sm text-slate-400">Upmix Threshold</div>
                     <div id="red-up-threshold" class="text-2xl font-bold text-white">-</div>
                   </div>
-                  <div class="text-center bg-slate-700/50 p-4 rounded-md">
-                    <div class="text-sm text-slate-400 mb-1">Downmix Threshold</div>
+                  <div class="rounded-md bg-slate-700/50 p-4 text-center">
+                    <div class="text-sm text-slate-400">Downmix Threshold</div>
                     <div id="red-down-threshold" class="text-2xl font-bold text-white">-</div>
                   </div>
                 </div>
               </div>
             </div>
-            
-            <div class="bg-slate-800/70 rounded-lg overflow-hidden shadow-lg mt-8">
-              <div class="p-5 text-center">
-                <h3 class="text-xl font-bold text-slate-100">DJ Mixing Zone Breakdown</h3>
-                <p class="text-sm text-slate-400">Axis layout showing original BPM cut points</p>
+
+            <div class="mt-8 overflow-hidden rounded-xl border border-slate-700/60 bg-slate-800/70 shadow-lg">
+              <div class="flex flex-col gap-4 border-b border-slate-700/60 p-5 lg:flex-row lg:items-center lg:justify-between">
+                <div>
+                  <h3 class="text-xl font-bold text-slate-100">Axis & Copy Actions</h3>
+                  <p class="text-sm text-slate-400">Monotonic ranges with copy buttons and Rekordbox CSV export.</p>
+                </div>
+                <div class="flex flex-wrap gap-3">
+                  <button id="copy-axis-button" type="button" class="inline-flex items-center justify-center rounded-md border border-slate-600/70 bg-slate-900/70 px-4 py-2 text-sm text-slate-200 transition-colors hover:bg-teal-700/80 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-50">
+                    Copy summary
+                  </button>
+                  <button id="copy-csv-button" type="button" class="inline-flex items-center justify-center rounded-md border border-slate-600/70 bg-slate-900/70 px-4 py-2 text-sm text-slate-200 transition-colors hover:bg-teal-700/80 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-50">
+                    Copy Rekordbox CSV
+                  </button>
+                  <button id="download-csv-button" type="button" class="inline-flex items-center justify-center rounded-md border border-teal-500/60 bg-teal-700/80 px-4 py-2 text-sm text-white transition-colors hover:bg-teal-600/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-50">
+                    Download CSV
+                  </button>
+                </div>
               </div>
-              <div class="overflow-x-auto">
-                <table class="w-full min-w-[600px] text-center">
-                  <thead class="bg-slate-800/50">
+              <div class="px-5 pt-4">
+                <p id="feedback-message" class="min-h-[1.5rem] text-sm text-teal-300" aria-live="polite"></p>
+              </div>
+              <div class="overflow-x-auto px-5 pb-5">
+                <table class="w-full min-w-[720px] text-left text-sm text-slate-200">
+                  <thead class="bg-slate-900/60 text-xs uppercase tracking-wide text-slate-300">
                     <tr>
-                      <th class="p-4 font-semibold text-slate-300 tracking-wider">Mix Direction</th>
-                      <th class="p-4 font-semibold text-slate-300 tracking-wider">Anchor (A)</th>
-                      <th class="p-4 font-semibold text-green-400 tracking-wider">Green Boundary (±G)</th>
-                      <th class="p-4 font-semibold text-yellow-400 tracking-wider">Yellow Boundary (±Y)</th>
-                      <th class="p-4 font-semibold text-red-400 tracking-wider">Red Threshold</th>
+                      <th class="px-4 py-3">Direction</th>
+                      <th class="px-4 py-3">Zone</th>
+                      <th class="px-4 py-3">Min BPM</th>
+                      <th class="px-4 py-3">Max BPM</th>
+                      <th class="px-4 py-3">Notes</th>
+                      <th class="px-4 py-3 text-center">Copy</th>
                     </tr>
                   </thead>
-                  <tbody class="text-slate-200 text-sm">
-                    <tr class="border-t border-slate-700/50">
-                      <td class="p-4 font-semibold bg-slate-800/40">Upmix (O &lt; A)</td>
-                      <td class="p-4 font-semibold bg-slate-800/40" id="table-up-anchor">-</td>
-                      <td class="p-4 font-semibold bg-teal-900/50" id="table-up-green">-</td>
-                      <td class="p-4 font-semibold" style="background-color: #4a4128;" id="table-up-yellow">-</td>
-                      <td class="p-4 font-semibold" style="background-color: #4f2b2b;" id="table-up-red">-</td>
-                    </tr>
-                    <tr class="border-t border-slate-700/50">
-                      <td class="p-4 font-semibold bg-slate-800/40">Downmix (O &gt; A)</td>
-                      <td class="p-4 font-semibold bg-slate-800/40" id="table-down-anchor">-</td>
-                      <td class="p-4 font-semibold bg-teal-900/50" id="table-down-green">-</td>
-                      <td class="p-4 font-semibold" style="background-color: #4a4128;" id="table-down-yellow">-</td>
-                      <td class="p-4 font-semibold" style="background-color: #4f2b2b;" id="table-down-red">-</td>
-                    </tr>
-                  </tbody>
+                  <tbody id="axis-body" class="divide-y divide-slate-800/60"></tbody>
                 </table>
               </div>
+              <div id="axis-empty-state" class="border-t border-slate-700/60 p-5 text-sm text-slate-400">Adjust parameters to generate the axis ranges.</div>
             </div>
           </section>
       </main>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,23 @@
+export default [
+  {
+    ignores: ['docs/assets/'],
+  },
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        window: 'readonly',
+        document: 'readonly',
+        navigator: 'readonly',
+        localStorage: 'readonly',
+        console: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        URL: 'readonly',
+      },
+    },
+    rules: {},
+  },
+];

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 
     <div class="min-h-screen bg-gradient-to-br from-slate-900 to-teal-950 text-slate-200 p-4 sm:p-6 lg:p-8">
       <main class="max-w-7xl mx-auto bg-slate-900/60 backdrop-blur-sm rounded-2xl shadow-2xl border border-teal-800/50 overflow-hidden">
-        
+
         <header class="bg-gradient-to-r from-slate-900 to-teal-950 text-white p-6 sm:p-8 text-center rounded-t-2xl">
           <h1 class="text-3xl sm:text-4xl font-bold text-slate-100 drop-shadow-lg">DJ BPM Zone Calculator</h1>
           <p class="mt-2 text-base sm:text-lg text-slate-300">Calculate optimal mixing zones based on groove analysis</p>
@@ -61,122 +61,160 @@
 
         <section class="p-6 sm:p-8">
           <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-            
-            <div class="flex flex-col">
-              <label for="anchorBpm" class="mb-2 font-semibold text-slate-300 text-sm">Anchor BPM (A)</label>
+
+            <div class="flex flex-col gap-3">
+              <label for="anchorBpm" class="font-semibold text-slate-300 text-sm">Anchor BPM (A)</label>
               <div class="relative">
                 <select id="anchorBpm" class="w-full px-4 py-3 bg-slate-800/50 border-2 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-teal-500 transition-colors duration-300 border-slate-700"></select>
                 <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-slate-400">
                   <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
                 </div>
               </div>
+              <p id="anchor-error" class="text-xs text-rose-300 min-h-[1.25rem]" style="visibility: hidden;" aria-live="polite" aria-hidden="true"></p>
+              <div id="quick-anchors" class="flex flex-wrap gap-2" role="group" aria-label="Quick anchors"></div>
             </div>
 
-            <div class="flex flex-col">
-              <label for="greenDev" class="mb-2 font-semibold text-slate-300 text-sm">Green Max Deviation (%)</label>
+            <div class="flex flex-col gap-3">
+              <label for="greenDev" class="font-semibold text-slate-300 text-sm">Green Max Deviation (%)</label>
               <div class="relative">
                   <select id="greenDev" class="w-full px-4 py-3 bg-slate-800/50 border-2 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-teal-500 transition-colors duration-300 border-slate-700"></select>
                   <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-slate-400">
                     <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
                   </div>
               </div>
+              <p id="green-error" class="text-xs text-rose-300 min-h-[1.25rem]" style="visibility: hidden;" aria-live="polite" aria-hidden="true"></p>
             </div>
 
-            <div class="flex flex-col">
-              <label for="yellowDev" class="mb-2 font-semibold text-slate-300 text-sm">Yellow Max Deviation (%)</label>
+            <div class="flex flex-col gap-3">
+              <label for="yellowDev" class="font-semibold text-slate-300 text-sm">Yellow Max Deviation (%)</label>
               <div class="relative">
                   <select id="yellowDev" class="w-full px-4 py-3 bg-slate-800/50 border-2 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-teal-500 transition-colors duration-300 border-slate-700"></select>
                   <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-slate-400">
                     <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
                   </div>
               </div>
+              <p id="yellow-error" class="text-xs text-rose-300 min-h-[1.25rem]" style="visibility: hidden;" aria-live="polite" aria-hidden="true"></p>
             </div>
-            
+
           </div>
 
-          <p id="error-message" class="mt-4 text-center text-red-400"></p>
+          <div class="mt-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div class="flex flex-col gap-1 text-sm text-slate-300 sm:flex-row sm:items-center sm:gap-2">
+              <span>Current anchor:</span>
+              <span id="current-anchor-label" class="text-lg font-semibold text-teal-300">—</span>
+            </div>
+            <button id="reset-defaults" type="button" class="inline-flex items-center gap-2 self-start rounded-md border border-slate-600/70 bg-slate-800/60 px-4 py-2 text-sm text-slate-200 transition-colors hover:bg-slate-700/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 sm:self-auto">
+              Reset to defaults
+            </button>
+          </div>
+
+          <p id="settings-summary" class="mt-3 text-center text-sm text-slate-400 sm:text-left"></p>
+          <p id="error-message" class="mt-4 text-center text-sm text-rose-300" aria-live="assertive"></p>
         </section>
-        
-        <section class="p-6 sm:p-8 pt-0" id="results" style="display: none;">
-            <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-              <!-- Green Zone Card -->
-              <div class="bg-slate-800/70 p-6 rounded-lg border-l-4 border-green-500 shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300">
-                <h3 class="text-xl font-bold text-white mb-4">Green Zone (Optimal Mix)</h3>
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <div class="text-center bg-slate-700/50 p-4 rounded-md">
-                    <div class="text-sm text-slate-400 mb-1">Upmix Range</div>
+
+        <section class="px-6 sm:px-8 pb-6">
+          <div class="space-y-4 rounded-xl border border-slate-700/60 bg-slate-900/60 p-5">
+            <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <h2 class="text-lg font-semibold text-slate-100">Presets</h2>
+                <p class="text-sm text-slate-400">Save and recall anchor & deviation combos for different sets.</p>
+              </div>
+              <div class="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-end">
+                <label class="flex w-full flex-col gap-2 text-sm text-slate-300 sm:w-64">
+                  <span class="font-medium">Preset name</span>
+                  <input id="preset-name" type="text" placeholder="e.g., Warm-up set" class="w-full rounded-md border border-slate-700/70 bg-slate-800/70 px-3 py-2 text-slate-100 placeholder:text-slate-500 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500" />
+                </label>
+                <button id="save-preset" type="button" class="inline-flex items-center justify-center rounded-md border border-teal-500/60 bg-teal-700/80 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-teal-600/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900">
+                  Save preset
+                </button>
+              </div>
+            </div>
+            <p id="presets-unavailable" class="text-sm text-amber-300 hidden">Presets require browser storage, which is unavailable in this session.</p>
+            <ul id="preset-list" class="flex flex-col gap-3"></ul>
+            <p id="preset-empty" class="text-sm text-slate-400 italic">No presets saved yet.</p>
+          </div>
+        </section>
+
+        <section class="hidden p-6 sm:p-8 pt-0" id="results" aria-hidden="true">
+            <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+              <div class="rounded-lg border-l-4 border-green-500 bg-slate-800/70 p-6 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl">
+                <h3 class="text-xl font-bold text-white">Green Zone (Optimal Mix)</h3>
+                <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div class="rounded-md bg-slate-700/50 p-4 text-center">
+                    <div class="text-sm text-slate-400">Upmix Range</div>
                     <div id="green-up-range" class="text-2xl font-bold text-white">-</div>
                   </div>
-                  <div class="text-center bg-slate-700/50 p-4 rounded-md">
-                    <div class="text-sm text-slate-400 mb-1">Downmix Range</div>
+                  <div class="rounded-md bg-slate-700/50 p-4 text-center">
+                    <div class="text-sm text-slate-400">Downmix Range</div>
                     <div id="green-down-range" class="text-2xl font-bold text-white">-</div>
                   </div>
                 </div>
               </div>
-              <!-- Yellow Zone Card -->
-              <div class="bg-slate-800/70 p-6 rounded-lg border-l-4 border-yellow-500 shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300">
-                <h3 class="text-xl font-bold text-white mb-4">Yellow Zone (Caution Mix)</h3>
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <div class="text-center bg-slate-700/50 p-4 rounded-md">
-                    <div class="text-sm text-slate-400 mb-1">Upmix Range</div>
+              <div class="rounded-lg border-l-4 border-yellow-500 bg-slate-800/70 p-6 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl">
+                <h3 class="text-xl font-bold text-white">Yellow Zone (Caution Mix)</h3>
+                <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div class="rounded-md bg-slate-700/50 p-4 text-center">
+                    <div class="text-sm text-slate-400">Upmix Range</div>
                     <div id="yellow-up-range" class="text-2xl font-bold text-white">-</div>
                   </div>
-                  <div class="text-center bg-slate-700/50 p-4 rounded-md">
-                    <div class="text-sm text-slate-400 mb-1">Downmix Range</div>
+                  <div class="rounded-md bg-slate-700/50 p-4 text-center">
+                    <div class="text-sm text-slate-400">Downmix Range</div>
                     <div id="yellow-down-range" class="text-2xl font-bold text-white">-</div>
                   </div>
                 </div>
               </div>
-              <!-- Red Zone Card -->
-              <div class="bg-slate-800/70 p-6 rounded-lg border-l-4 border-red-500 shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300">
-                <h3 class="text-xl font-bold text-white mb-4">Red Zone (Avoid Mix)</h3>
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <div class="text-center bg-slate-700/50 p-4 rounded-md">
-                    <div class="text-sm text-slate-400 mb-1">Upmix Threshold</div>
+              <div class="rounded-lg border-l-4 border-red-500 bg-slate-800/70 p-6 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl">
+                <h3 class="text-xl font-bold text-white">Red Zone (Avoid Mix)</h3>
+                <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div class="rounded-md bg-slate-700/50 p-4 text-center">
+                    <div class="text-sm text-slate-400">Upmix Threshold</div>
                     <div id="red-up-threshold" class="text-2xl font-bold text-white">-</div>
                   </div>
-                  <div class="text-center bg-slate-700/50 p-4 rounded-md">
-                    <div class="text-sm text-slate-400 mb-1">Downmix Threshold</div>
+                  <div class="rounded-md bg-slate-700/50 p-4 text-center">
+                    <div class="text-sm text-slate-400">Downmix Threshold</div>
                     <div id="red-down-threshold" class="text-2xl font-bold text-white">-</div>
                   </div>
                 </div>
               </div>
             </div>
-            
-            <div class="bg-slate-800/70 rounded-lg overflow-hidden shadow-lg mt-8">
-              <div class="p-5 text-center">
-                <h3 class="text-xl font-bold text-slate-100">DJ Mixing Zone Breakdown</h3>
-                <p class="text-sm text-slate-400">Axis layout showing original BPM cut points</p>
+
+            <div class="mt-8 overflow-hidden rounded-xl border border-slate-700/60 bg-slate-800/70 shadow-lg">
+              <div class="flex flex-col gap-4 border-b border-slate-700/60 p-5 lg:flex-row lg:items-center lg:justify-between">
+                <div>
+                  <h3 class="text-xl font-bold text-slate-100">Axis & Copy Actions</h3>
+                  <p class="text-sm text-slate-400">Monotonic ranges with copy buttons and Rekordbox CSV export.</p>
+                </div>
+                <div class="flex flex-wrap gap-3">
+                  <button id="copy-axis-button" type="button" class="inline-flex items-center justify-center rounded-md border border-slate-600/70 bg-slate-900/70 px-4 py-2 text-sm text-slate-200 transition-colors hover:bg-teal-700/80 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-50">
+                    Copy summary
+                  </button>
+                  <button id="copy-csv-button" type="button" class="inline-flex items-center justify-center rounded-md border border-slate-600/70 bg-slate-900/70 px-4 py-2 text-sm text-slate-200 transition-colors hover:bg-teal-700/80 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-50">
+                    Copy Rekordbox CSV
+                  </button>
+                  <button id="download-csv-button" type="button" class="inline-flex items-center justify-center rounded-md border border-teal-500/60 bg-teal-700/80 px-4 py-2 text-sm text-white transition-colors hover:bg-teal-600/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-50">
+                    Download CSV
+                  </button>
+                </div>
               </div>
-              <div class="overflow-x-auto">
-                <table class="w-full min-w-[600px] text-center">
-                  <thead class="bg-slate-800/50">
+              <div class="px-5 pt-4">
+                <p id="feedback-message" class="min-h-[1.5rem] text-sm text-teal-300" aria-live="polite"></p>
+              </div>
+              <div class="overflow-x-auto px-5 pb-5">
+                <table class="w-full min-w-[720px] text-left text-sm text-slate-200">
+                  <thead class="bg-slate-900/60 text-xs uppercase tracking-wide text-slate-300">
                     <tr>
-                      <th class="p-4 font-semibold text-slate-300 tracking-wider">Mix Direction</th>
-                      <th class="p-4 font-semibold text-slate-300 tracking-wider">Anchor (A)</th>
-                      <th class="p-4 font-semibold text-green-400 tracking-wider">Green Boundary (±G)</th>
-                      <th class="p-4 font-semibold text-yellow-400 tracking-wider">Yellow Boundary (±Y)</th>
-                      <th class="p-4 font-semibold text-red-400 tracking-wider">Red Threshold</th>
+                      <th class="px-4 py-3">Direction</th>
+                      <th class="px-4 py-3">Zone</th>
+                      <th class="px-4 py-3">Min BPM</th>
+                      <th class="px-4 py-3">Max BPM</th>
+                      <th class="px-4 py-3">Notes</th>
+                      <th class="px-4 py-3 text-center">Copy</th>
                     </tr>
                   </thead>
-                  <tbody class="text-slate-200 text-sm">
-                    <tr class="border-t border-slate-700/50">
-                      <td class="p-4 font-semibold bg-slate-800/40">Upmix (O &lt; A)</td>
-                      <td class="p-4 font-semibold bg-slate-800/40" id="table-up-anchor">-</td>
-                      <td class="p-4 font-semibold bg-teal-900/50" id="table-up-green">-</td>
-                      <td class="p-4 font-semibold" style="background-color: #4a4128;" id="table-up-yellow">-</td>
-                      <td class="p-4 font-semibold" style="background-color: #4f2b2b;" id="table-up-red">-</td>
-                    </tr>
-                    <tr class="border-t border-slate-700/50">
-                      <td class="p-4 font-semibold bg-slate-800/40">Downmix (O &gt; A)</td>
-                      <td class="p-4 font-semibold bg-slate-800/40" id="table-down-anchor">-</td>
-                      <td class="p-4 font-semibold bg-teal-900/50" id="table-down-green">-</td>
-                      <td class="p-4 font-semibold" style="background-color: #4a4128;" id="table-down-yellow">-</td>
-                      <td class="p-4 font-semibold" style="background-color: #4f2b2b;" id="table-down-red">-</td>
-                    </tr>
-                  </tbody>
+                  <tbody id="axis-body" class="divide-y divide-slate-800/60"></tbody>
                 </table>
               </div>
+              <div id="axis-empty-state" class="border-t border-slate-700/60 p-5 text-sm text-slate-400">Adjust parameters to generate the axis ranges.</div>
             </div>
           </section>
       </main>

--- a/roadmap.md
+++ b/roadmap.md
@@ -14,7 +14,8 @@ A lightweight web app that maps an anchor BPM and deviation percentages to color
 
 ---
 
-## Phase 0 — Project hygiene *(SMALL)*
+## Phase 0 — Project hygiene *(SMALL)* ✅ Completed
+**Status:** ✅ Completed.
 **Goal:** Make the repo robust and safe to change.
 
 **Tasks**
@@ -30,7 +31,8 @@ A lightweight web app that maps an anchor BPM and deviation percentages to color
 
 ---
 
-## Phase 1 — Harden UX & deterministic features *(MEDIUM)*
+## Phase 1 — Harden UX & deterministic features *(MEDIUM)* ✅ Completed
+**Status:** ✅ Completed.
 **Goal:** Make the app delightful and copyable for DJs.
 
 **Tasks**

--- a/src/calculation.js
+++ b/src/calculation.js
@@ -15,40 +15,60 @@ function isNumber(value) {
 }
 
 export function validateInputs(anchor, greenPct, yellowPct) {
-  if (!isNumber(anchor) || !isNumber(greenPct) || !isNumber(yellowPct)) {
-    return { valid: false, message: 'Anchor and deviation values must be numbers.' };
+  const errors = {};
+
+  if (!isNumber(anchor)) {
+    errors.anchor = 'Anchor BPM must be a number.';
+  } else if (!Number.isInteger(anchor)) {
+    errors.anchor = 'Anchor BPM must be a whole number.';
   }
 
-  if (anchor < ANCHOR_MIN || anchor > ANCHOR_MAX) {
-    return {
-      valid: false,
-      message: `Anchor BPM must be between ${ANCHOR_MIN} and ${ANCHOR_MAX}.`,
-    };
+  if (!isNumber(greenPct)) {
+    errors.green = 'Green deviation must be a number.';
+  } else if (!Number.isInteger(greenPct)) {
+    errors.green = 'Green deviation must be a whole number.';
   }
 
-  if (greenPct < GREEN_MIN || greenPct > GREEN_MAX) {
-    return {
-      valid: false,
-      message: `Green deviation must be between ${GREEN_MIN}% and ${GREEN_MAX}%.`,
-    };
+  if (!isNumber(yellowPct)) {
+    errors.yellow = 'Yellow deviation must be a number.';
+  } else if (!Number.isInteger(yellowPct)) {
+    errors.yellow = 'Yellow deviation must be a whole number.';
   }
 
-  if (yellowPct < YELLOW_MIN || yellowPct > YELLOW_MAX) {
-    return {
-      valid: false,
-      message: `Yellow deviation must be between ${YELLOW_MIN}% and ${YELLOW_MAX}%.`,
-    };
+  if (!errors.anchor) {
+    if (anchor < ANCHOR_MIN || anchor > ANCHOR_MAX) {
+      errors.anchor = `Anchor BPM must be between ${ANCHOR_MIN} and ${ANCHOR_MAX}.`;
+    }
   }
 
-  if (greenPct >= yellowPct) {
-    return { valid: false, message: 'Yellow deviation must be greater than green deviation.' };
+  if (!errors.green) {
+    if (greenPct < GREEN_MIN || greenPct > GREEN_MAX) {
+      errors.green = `Green deviation must be between ${GREEN_MIN}% and ${GREEN_MAX}%.`;
+    } else if (greenPct > PERCENTAGE_MAX) {
+      errors.green = 'Green deviation must be 100% or less.';
+    }
   }
 
-  if (greenPct > PERCENTAGE_MAX || yellowPct > PERCENTAGE_MAX) {
-    return { valid: false, message: 'Deviations must be 100% or less.' };
+  if (!errors.yellow) {
+    if (yellowPct < YELLOW_MIN || yellowPct > YELLOW_MAX) {
+      errors.yellow = `Yellow deviation must be between ${YELLOW_MIN}% and ${YELLOW_MAX}%.`;
+    } else if (yellowPct > PERCENTAGE_MAX) {
+      errors.yellow = 'Yellow deviation must be 100% or less.';
+    }
   }
 
-  return { valid: true };
+  if (!errors.green && !errors.yellow && greenPct >= yellowPct) {
+    errors.yellow = 'Yellow deviation must be greater than green deviation.';
+  }
+
+  const errorKeys = Object.keys(errors);
+
+  if (errorKeys.length > 0) {
+    const field = errorKeys[0];
+    return { valid: false, message: errors[field], field, errors };
+  }
+
+  return { valid: true, errors: {} };
 }
 
 function calculateDeviation(anchor, percentage) {

--- a/src/main.js
+++ b/src/main.js
@@ -13,8 +13,31 @@ import {
   formatThreshold,
   validateInputs,
 } from './calculation.js';
+import { buildAxisRows, buildAxisCsv } from './ui-logic.js';
 
 const STEP_ONE = 1;
+const QUICK_ANCHORS = [128, 130, 133, 136, 140];
+const PRESET_STORAGE_KEY = 'dj-bpm-zone-presets-v1';
+const FEEDBACK_CLEAR_DELAY = 3500;
+
+let quickAnchorButtons = [];
+let currentAxisRows = [];
+let currentMixingZones = null;
+let feedbackTimeoutId = null;
+let presets = [];
+
+const storageAvailable =
+  typeof window !== 'undefined' &&
+  (() => {
+    try {
+      const testKey = '__dj_bpm_storage_test__';
+      window.localStorage.setItem(testKey, '1');
+      window.localStorage.removeItem(testKey);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  })();
 
 function populateSelect(selectEl, min, max, step, unit, defaultValue) {
   selectEl.innerHTML = '';
@@ -22,37 +45,10 @@ function populateSelect(selectEl, min, max, step, unit, defaultValue) {
     const option = document.createElement('option');
     option.value = value;
     option.textContent = `${value}${unit}`;
-    option.className = 'bg-slate-800';
+    option.className = 'bg-slate-800 text-slate-100';
     selectEl.appendChild(option);
   }
   selectEl.value = String(defaultValue);
-}
-
-function renderError(errorMessageEl, resultsSectionEl, message) {
-  errorMessageEl.textContent = message;
-  resultsSectionEl.style.display = 'none';
-}
-
-function renderResults(results, elements, resultsSectionEl) {
-  const { green, yellow, red, anchor } = results;
-
-  elements.greenUpRange.textContent = formatBpm(green.up);
-  elements.greenDownRange.textContent = formatBpm(green.down);
-  elements.yellowUpRange.textContent = formatBpm(yellow.up);
-  elements.yellowDownRange.textContent = formatBpm(yellow.down);
-  elements.redUpThreshold.textContent = formatThreshold('<', red.upThreshold);
-  elements.redDownThreshold.textContent = formatThreshold('>', red.downThreshold);
-
-  elements.tableUpAnchor.textContent = formatBpm(anchor);
-  elements.tableUpGreen.textContent = formatBpm(green.up);
-  elements.tableUpYellow.textContent = formatBpm(yellow.up);
-  elements.tableUpRed.textContent = formatThreshold('<', red.upThreshold);
-  elements.tableDownAnchor.textContent = formatBpm(anchor);
-  elements.tableDownGreen.textContent = formatBpm(green.down);
-  elements.tableDownYellow.textContent = formatBpm(yellow.down);
-  elements.tableDownRed.textContent = formatThreshold('>', red.downThreshold);
-
-  resultsSectionEl.style.display = 'block';
 }
 
 function getElements() {
@@ -60,6 +56,14 @@ function getElements() {
     anchorSelect: document.getElementById('anchorBpm'),
     greenSelect: document.getElementById('greenDev'),
     yellowSelect: document.getElementById('yellowDev'),
+    fieldErrors: {
+      anchor: document.getElementById('anchor-error'),
+      green: document.getElementById('green-error'),
+      yellow: document.getElementById('yellow-error'),
+    },
+    quickAnchorsContainer: document.getElementById('quick-anchors'),
+    currentAnchorLabel: document.getElementById('current-anchor-label'),
+    settingsSummary: document.getElementById('settings-summary'),
     errorMessage: document.getElementById('error-message'),
     resultsSection: document.getElementById('results'),
     greenUpRange: document.getElementById('green-up-range'),
@@ -68,19 +72,634 @@ function getElements() {
     yellowDownRange: document.getElementById('yellow-down-range'),
     redUpThreshold: document.getElementById('red-up-threshold'),
     redDownThreshold: document.getElementById('red-down-threshold'),
-    tableUpAnchor: document.getElementById('table-up-anchor'),
-    tableUpGreen: document.getElementById('table-up-green'),
-    tableUpYellow: document.getElementById('table-up-yellow'),
-    tableUpRed: document.getElementById('table-up-red'),
-    tableDownAnchor: document.getElementById('table-down-anchor'),
-    tableDownGreen: document.getElementById('table-down-green'),
-    tableDownYellow: document.getElementById('table-down-yellow'),
-    tableDownRed: document.getElementById('table-down-red'),
+    copyFeedback: document.getElementById('feedback-message'),
+    axisBody: document.getElementById('axis-body'),
+    axisEmptyState: document.getElementById('axis-empty-state'),
+    copyAxisButton: document.getElementById('copy-axis-button'),
+    copyCsvButton: document.getElementById('copy-csv-button'),
+    downloadCsvButton: document.getElementById('download-csv-button'),
+    presetNameInput: document.getElementById('preset-name'),
+    savePresetButton: document.getElementById('save-preset'),
+    presetList: document.getElementById('preset-list'),
+    presetEmptyState: document.getElementById('preset-empty'),
+    presetsUnavailable: document.getElementById('presets-unavailable'),
+    resetButton: document.getElementById('reset-defaults'),
   };
+}
+
+function setFieldError(element, message) {
+  if (!element) {
+    return;
+  }
+  element.textContent = message || '';
+  element.style.visibility = message ? 'visible' : 'hidden';
+  element.setAttribute('aria-hidden', message ? 'false' : 'true');
+}
+
+function renderInlineErrors(errors, elements) {
+  const { fieldErrors, errorMessage } = elements;
+  if (!fieldErrors) {
+    return;
+  }
+
+  setFieldError(fieldErrors.anchor, errors?.anchor);
+  setFieldError(fieldErrors.green, errors?.green);
+  setFieldError(fieldErrors.yellow, errors?.yellow);
+
+  if (errorMessage) {
+    if (errors && Object.keys(errors).length > 0) {
+      errorMessage.textContent = Object.values(errors)[0];
+    } else {
+      errorMessage.textContent = '';
+    }
+  }
+}
+
+function toggleResultsVisibility(elements, show) {
+  if (!elements.resultsSection) {
+    return;
+  }
+  if (show) {
+    elements.resultsSection.classList.remove('hidden');
+    elements.resultsSection.setAttribute('aria-hidden', 'false');
+  } else {
+    elements.resultsSection.classList.add('hidden');
+    elements.resultsSection.setAttribute('aria-hidden', 'true');
+  }
+}
+
+function renderResultsCards(results, elements, selection) {
+  const { anchor, green, yellow, red } = results;
+
+  if (elements.greenUpRange) {
+    elements.greenUpRange.textContent = formatBpm(green.up);
+  }
+  if (elements.greenDownRange) {
+    elements.greenDownRange.textContent = formatBpm(green.down);
+  }
+  if (elements.yellowUpRange) {
+    elements.yellowUpRange.textContent = formatBpm(yellow.up);
+  }
+  if (elements.yellowDownRange) {
+    elements.yellowDownRange.textContent = formatBpm(yellow.down);
+  }
+  if (elements.redUpThreshold) {
+    elements.redUpThreshold.textContent = formatThreshold('<', red.upThreshold);
+  }
+  if (elements.redDownThreshold) {
+    elements.redDownThreshold.textContent = formatThreshold('>', red.downThreshold);
+  }
+  if (elements.currentAnchorLabel) {
+    elements.currentAnchorLabel.textContent = formatBpm(anchor);
+  }
+  if (elements.settingsSummary && selection) {
+    const summaryParts = [
+      `Anchor ${formatBpm(anchor)}`,
+      `Green ±${selection.greenPct}%`,
+      `Yellow ±${selection.yellowPct}%`,
+    ];
+    elements.settingsSummary.textContent = summaryParts.join(' • ');
+  }
+}
+
+function updateQuickAnchorSelection(anchorValue) {
+  quickAnchorButtons.forEach((button) => {
+    const isActive = Number(button.dataset.anchor) === anchorValue;
+    button.classList.toggle('bg-teal-600/80', isActive);
+    button.classList.toggle('border-teal-400/80', isActive);
+    button.classList.toggle('text-teal-50', isActive);
+    button.classList.toggle('bg-slate-800/60', !isActive);
+    button.classList.toggle('border-slate-700/70', !isActive);
+    button.classList.toggle('text-slate-200', !isActive);
+    button.setAttribute('aria-pressed', String(isActive));
+  });
+}
+
+function renderAxis(rows, elements) {
+  const { axisBody, axisEmptyState, copyAxisButton, copyCsvButton, downloadCsvButton } = elements;
+  if (!axisBody) {
+    return;
+  }
+
+  axisBody.innerHTML = '';
+
+  if (!rows.length) {
+    if (axisEmptyState) {
+      axisEmptyState.classList.remove('hidden');
+    }
+    if (copyAxisButton) {
+      copyAxisButton.disabled = true;
+    }
+    if (copyCsvButton) {
+      copyCsvButton.disabled = true;
+    }
+    if (downloadCsvButton) {
+      downloadCsvButton.disabled = true;
+    }
+    return;
+  }
+
+  if (axisEmptyState) {
+    axisEmptyState.classList.add('hidden');
+  }
+
+  const fragment = document.createDocumentFragment();
+
+  rows.forEach((row) => {
+    const tr = document.createElement('tr');
+    tr.className = 'hover:bg-slate-800/40 transition-colors';
+
+    const directionCell = document.createElement('td');
+    directionCell.className = 'px-4 py-3 font-semibold uppercase text-xs tracking-wide text-slate-300';
+    directionCell.textContent = row.direction;
+    tr.appendChild(directionCell);
+
+    const zoneCell = document.createElement('td');
+    zoneCell.className = 'px-4 py-3 font-medium';
+    zoneCell.textContent = row.zone;
+    if (row.zone.includes('Anchor')) {
+      zoneCell.classList.add('text-teal-200');
+    } else if (row.zone === 'Green') {
+      zoneCell.classList.add('text-green-300');
+    } else if (row.zone === 'Yellow') {
+      zoneCell.classList.add('text-amber-300');
+    } else if (row.zone === 'Red') {
+      zoneCell.classList.add('text-red-300');
+    }
+    tr.appendChild(zoneCell);
+
+    const minCell = document.createElement('td');
+    minCell.className = 'px-4 py-3 text-slate-200';
+    minCell.textContent = row.minLabel;
+    tr.appendChild(minCell);
+
+    const maxCell = document.createElement('td');
+    maxCell.className = 'px-4 py-3 text-slate-200';
+    maxCell.textContent = row.maxLabel;
+    tr.appendChild(maxCell);
+
+    const notesCell = document.createElement('td');
+    notesCell.className = 'px-4 py-3 text-sm text-slate-300';
+    notesCell.textContent = row.description;
+    tr.appendChild(notesCell);
+
+    const copyCell = document.createElement('td');
+    copyCell.className = 'px-4 py-3 text-center';
+    const copyButton = document.createElement('button');
+    copyButton.type = 'button';
+    copyButton.dataset.copyText = row.copyText;
+    copyButton.dataset.copyLabel = `${row.direction} ${row.zone}`;
+    copyButton.className =
+      'inline-flex items-center justify-center gap-2 rounded-md border px-3 py-1.5 text-xs sm:text-sm transition-colors ' +
+      'bg-slate-900/70 border-slate-700/80 text-slate-200 hover:bg-teal-700/80 hover:text-white hover:border-teal-500/70 ' +
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900';
+    copyButton.textContent = 'Copy';
+    copyCell.appendChild(copyButton);
+    tr.appendChild(copyCell);
+
+    fragment.appendChild(tr);
+  });
+
+  axisBody.appendChild(fragment);
+
+  if (copyAxisButton) {
+    copyAxisButton.disabled = false;
+  }
+  if (copyCsvButton) {
+    copyCsvButton.disabled = false;
+  }
+  if (downloadCsvButton) {
+    downloadCsvButton.disabled = false;
+  }
+}
+
+function clearFeedback(elements) {
+  if (!elements.copyFeedback) {
+    return;
+  }
+  elements.copyFeedback.textContent = '';
+  elements.copyFeedback.classList.remove('text-teal-300', 'text-rose-300', 'text-slate-200');
+}
+
+function showFeedback(elements, message, tone = 'info') {
+  if (!elements.copyFeedback) {
+    return;
+  }
+
+  clearTimeout(feedbackTimeoutId);
+  clearFeedback(elements);
+
+  const toneClass = tone === 'success' ? 'text-teal-300' : tone === 'error' ? 'text-rose-300' : 'text-slate-200';
+  elements.copyFeedback.classList.add(toneClass);
+  elements.copyFeedback.textContent = message;
+
+  feedbackTimeoutId = window.setTimeout(() => {
+    clearFeedback(elements);
+  }, FEEDBACK_CLEAR_DELAY);
+}
+
+async function copyToClipboard(text) {
+  if (!text) {
+    return false;
+  }
+
+  try {
+    if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch (error) {
+    // Fall back to legacy approach below.
+  }
+
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.setAttribute('readonly', '');
+  textArea.style.position = 'absolute';
+  textArea.style.left = '-9999px';
+  document.body.appendChild(textArea);
+  textArea.select();
+
+  let success = false;
+  try {
+    success = document.execCommand('copy');
+  } catch (error) {
+    success = false;
+  }
+
+  document.body.removeChild(textArea);
+  return success;
+}
+
+function handleAxisCopyClick(event, elements) {
+  const button = event.target.closest('button[data-copy-text]');
+  if (!button) {
+    return;
+  }
+
+  const { copyText, copyLabel } = button.dataset;
+  if (!copyText) {
+    showFeedback(elements, 'Nothing to copy for this row.', 'error');
+    return;
+  }
+
+  copyToClipboard(copyText).then((success) => {
+    if (success) {
+      showFeedback(elements, `${copyLabel || 'Range'} copied to clipboard.`, 'success');
+    } else {
+      showFeedback(elements, 'Unable to copy to clipboard.', 'error');
+    }
+  });
+}
+
+function handleCopySummary(elements) {
+  if (!currentAxisRows.length) {
+    showFeedback(elements, 'Generate axis ranges before copying.', 'error');
+    return;
+  }
+  const summary = currentAxisRows.map((row) => row.copyText).join('\n');
+  copyToClipboard(summary).then((success) => {
+    if (success) {
+      showFeedback(elements, 'Axis summary copied to clipboard.', 'success');
+    } else {
+      showFeedback(elements, 'Unable to copy axis summary.', 'error');
+    }
+  });
+}
+
+function handleCopyCsv(elements) {
+  if (!currentAxisRows.length || !currentMixingZones) {
+    showFeedback(elements, 'Generate axis ranges before copying CSV.', 'error');
+    return;
+  }
+
+  const csv = buildAxisCsv(currentAxisRows, currentMixingZones.anchor);
+  copyToClipboard(csv).then((success) => {
+    if (success) {
+      showFeedback(elements, 'Rekordbox CSV copied to clipboard.', 'success');
+    } else {
+      showFeedback(elements, 'Unable to copy CSV.', 'error');
+    }
+  });
+}
+
+function handleDownloadCsv(elements) {
+  if (!currentAxisRows.length || !currentMixingZones) {
+    showFeedback(elements, 'Generate axis ranges before downloading CSV.', 'error');
+    return;
+  }
+
+  const csv = buildAxisCsv(currentAxisRows, currentMixingZones.anchor);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `dj-bpm-axis-${currentMixingZones.anchor}bpm.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+  showFeedback(elements, 'CSV download started.', 'success');
+}
+
+function createPresetId() {
+  return `preset-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function sanitizePreset(preset) {
+  if (!preset || typeof preset !== 'object') {
+    return null;
+  }
+  if (typeof preset.name !== 'string') {
+    return null;
+  }
+  const name = preset.name.trim();
+  if (!name) {
+    return null;
+  }
+  const anchor = Number(preset.anchor);
+  const green = Number(preset.green);
+  const yellow = Number(preset.yellow);
+  if (!Number.isInteger(anchor) || !Number.isInteger(green) || !Number.isInteger(yellow)) {
+    return null;
+  }
+  const validation = validateInputs(anchor, green, yellow);
+  if (!validation.valid) {
+    return null;
+  }
+  return {
+    id: typeof preset.id === 'string' ? preset.id : createPresetId(),
+    name,
+    anchor,
+    green,
+    yellow,
+    savedAt: typeof preset.savedAt === 'string' ? preset.savedAt : new Date().toISOString(),
+  };
+}
+
+function loadPresets() {
+  if (!storageAvailable) {
+    return [];
+  }
+  try {
+    const raw = window.localStorage.getItem(PRESET_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .map((preset) => sanitizePreset(preset))
+      .filter((preset) => preset !== null);
+  } catch (error) {
+    console.warn('Failed to load presets from storage', error);
+    return [];
+  }
+}
+
+function persistPresets() {
+  if (!storageAvailable) {
+    return false;
+  }
+  try {
+    window.localStorage.setItem(PRESET_STORAGE_KEY, JSON.stringify(presets));
+    return true;
+  } catch (error) {
+    console.warn('Failed to persist presets', error);
+    return false;
+  }
+}
+
+function renderPresetList(elements) {
+  const { presetList, presetEmptyState } = elements;
+  if (!presetList) {
+    return;
+  }
+
+  presetList.innerHTML = '';
+
+  if (!presets.length) {
+    if (presetEmptyState) {
+      presetEmptyState.classList.remove('hidden');
+    }
+    return;
+  }
+
+  if (presetEmptyState) {
+    presetEmptyState.classList.add('hidden');
+  }
+
+  const sorted = [...presets].sort((a, b) => {
+    const aTime = new Date(a.savedAt).getTime();
+    const bTime = new Date(b.savedAt).getTime();
+    return bTime - aTime;
+  });
+
+  const fragment = document.createDocumentFragment();
+  sorted.forEach((preset) => {
+    const listItem = document.createElement('li');
+    listItem.className =
+      'flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between rounded-lg border border-slate-700/60 bg-slate-900/60 p-4';
+
+    const infoWrapper = document.createElement('div');
+    const nameEl = document.createElement('p');
+    nameEl.className = 'text-sm font-semibold text-slate-100';
+    nameEl.textContent = preset.name;
+    const detailEl = document.createElement('p');
+    detailEl.className = 'text-xs text-slate-400';
+    detailEl.textContent = `A${preset.anchor} • G±${preset.green}% • Y±${preset.yellow}%`;
+    infoWrapper.appendChild(nameEl);
+    infoWrapper.appendChild(detailEl);
+
+    const actions = document.createElement('div');
+    actions.className = 'flex flex-wrap gap-2';
+
+    const loadButton = document.createElement('button');
+    loadButton.type = 'button';
+    loadButton.dataset.action = 'load';
+    loadButton.dataset.presetId = preset.id;
+    loadButton.className =
+      'px-3 py-1.5 text-xs sm:text-sm rounded-md bg-teal-700/80 text-white border border-teal-500/60 hover:bg-teal-600/80 ' +
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900';
+    loadButton.textContent = 'Load';
+
+    const deleteButton = document.createElement('button');
+    deleteButton.type = 'button';
+    deleteButton.dataset.action = 'delete';
+    deleteButton.dataset.presetId = preset.id;
+    deleteButton.className =
+      'px-3 py-1.5 text-xs sm:text-sm rounded-md border border-slate-600/70 text-slate-200 hover:bg-slate-800/70 hover:text-white ' +
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900';
+    deleteButton.textContent = 'Delete';
+
+    actions.appendChild(loadButton);
+    actions.appendChild(deleteButton);
+
+    listItem.appendChild(infoWrapper);
+    listItem.appendChild(actions);
+
+    fragment.appendChild(listItem);
+  });
+
+  presetList.appendChild(fragment);
+}
+
+function handleSavePreset(elements) {
+  if (!storageAvailable) {
+    showFeedback(elements, 'Browser storage is unavailable. Presets are disabled.', 'error');
+    return;
+  }
+
+  const name = elements.presetNameInput?.value.trim();
+  if (!name) {
+    showFeedback(elements, 'Enter a name before saving a preset.', 'error');
+    if (elements.presetNameInput) {
+      elements.presetNameInput.focus();
+    }
+    return;
+  }
+
+  const anchor = Number(elements.anchorSelect.value);
+  const greenPct = Number(elements.greenSelect.value);
+  const yellowPct = Number(elements.yellowSelect.value);
+  const validation = validateInputs(anchor, greenPct, yellowPct);
+  if (!validation.valid) {
+    showFeedback(elements, `Cannot save preset: ${validation.message}`, 'error');
+    return;
+  }
+
+  const existingIndex = presets.findIndex((preset) => preset.name.toLowerCase() === name.toLowerCase());
+  const presetData = {
+    id: existingIndex >= 0 ? presets[existingIndex].id : createPresetId(),
+    name,
+    anchor,
+    green: greenPct,
+    yellow: yellowPct,
+    savedAt: new Date().toISOString(),
+  };
+
+  if (existingIndex >= 0) {
+    presets[existingIndex] = presetData;
+  } else {
+    presets.push(presetData);
+  }
+
+  if (!persistPresets()) {
+    showFeedback(elements, 'Unable to save preset to browser storage.', 'error');
+    return;
+  }
+
+  renderPresetList(elements);
+  showFeedback(elements, `Preset “${name}” saved.`, 'success');
+}
+
+function applyPreset(preset, elements, handleChange) {
+  if (!preset) {
+    return;
+  }
+  elements.anchorSelect.value = String(preset.anchor);
+  elements.greenSelect.value = String(preset.green);
+  elements.yellowSelect.value = String(preset.yellow);
+  handleChange();
+  elements.anchorSelect.focus({ preventScroll: true });
+}
+
+function handlePresetListAction(event, elements, handleChange) {
+  const button = event.target.closest('button[data-action][data-preset-id]');
+  if (!button) {
+    return;
+  }
+
+  const { action, presetId } = button.dataset;
+  const preset = presets.find((item) => item.id === presetId);
+
+  if (action === 'load' && preset) {
+    applyPreset(preset, elements, handleChange);
+    showFeedback(elements, `Preset “${preset.name}” loaded.`, 'success');
+    if (elements.presetNameInput) {
+      elements.presetNameInput.value = preset.name;
+    }
+  } else if (action === 'delete' && preset) {
+    presets = presets.filter((item) => item.id !== presetId);
+    if (!persistPresets()) {
+      showFeedback(elements, 'Unable to update presets in storage.', 'error');
+      return;
+    }
+    renderPresetList(elements);
+    showFeedback(elements, 'Preset deleted.', 'info');
+  }
+}
+
+function resetToDefaults(elements, handleChange) {
+  elements.anchorSelect.value = String(DEFAULT_ANCHOR);
+  elements.greenSelect.value = String(DEFAULT_GREEN_DEV);
+  elements.yellowSelect.value = String(DEFAULT_YELLOW_DEV);
+  handleChange();
+  elements.anchorSelect.focus({ preventScroll: true });
+}
+
+function initQuickAnchors(elements, handleChange) {
+  const container = elements.quickAnchorsContainer;
+  if (!container) {
+    return;
+  }
+
+  container.innerHTML = '';
+  quickAnchorButtons = [];
+
+  QUICK_ANCHORS.forEach((anchorValue) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.dataset.anchor = String(anchorValue);
+    button.className =
+      'px-3 py-1.5 text-xs sm:text-sm rounded-md border bg-slate-800/60 border-slate-700/70 text-slate-200 transition-colors ' +
+      'hover:bg-teal-600/80 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 ' +
+      'focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900';
+    button.textContent = `${anchorValue} BPM`;
+    button.setAttribute('aria-pressed', 'false');
+    button.addEventListener('click', () => {
+      elements.anchorSelect.value = String(anchorValue);
+      handleChange();
+    });
+    quickAnchorButtons.push(button);
+    container.appendChild(button);
+  });
+}
+
+function initPresetsSection(elements, handleChange) {
+  if (!elements.presetNameInput || !elements.savePresetButton || !elements.presetList) {
+    return;
+  }
+
+  if (!storageAvailable) {
+    elements.presetNameInput.disabled = true;
+    elements.savePresetButton.disabled = true;
+    if (elements.presetsUnavailable) {
+      elements.presetsUnavailable.classList.remove('hidden');
+    }
+    return;
+  }
+
+  presets = loadPresets();
+  renderPresetList(elements);
+
+  elements.savePresetButton.addEventListener('click', () => handleSavePreset(elements));
+  elements.presetNameInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleSavePreset(elements);
+    }
+  });
+  elements.presetList.addEventListener('click', (event) => handlePresetListAction(event, elements, handleChange));
 }
 
 function init() {
   const elements = getElements();
+  if (!elements.anchorSelect || !elements.greenSelect || !elements.yellowSelect) {
+    return;
+  }
 
   populateSelect(
     elements.anchorSelect,
@@ -109,28 +728,66 @@ function init() {
 
   const handleChange = () => {
     const anchor = Number(elements.anchorSelect.value);
-    const green = Number(elements.greenSelect.value);
-    const yellow = Number(elements.yellowSelect.value);
+    const greenPct = Number(elements.greenSelect.value);
+    const yellowPct = Number(elements.yellowSelect.value);
 
-    const validation = validateInputs(anchor, green, yellow);
+    clearFeedback(elements);
+
+    const validation = validateInputs(anchor, greenPct, yellowPct);
+    renderInlineErrors(validation.errors, elements);
 
     if (!validation.valid) {
-      renderError(elements.errorMessage, elements.resultsSection, validation.message);
+      toggleResultsVisibility(elements, false);
+      if (elements.currentAnchorLabel) {
+        elements.currentAnchorLabel.textContent = '—';
+      }
+      if (elements.settingsSummary) {
+        elements.settingsSummary.textContent = '';
+      }
+      currentAxisRows = [];
+      currentMixingZones = null;
+      renderAxis([], elements);
       return;
     }
 
-    elements.errorMessage.textContent = '';
-
-    const results = calculateMixingZones(anchor, green, yellow);
-    renderResults(results, elements, elements.resultsSection);
+    const results = calculateMixingZones(anchor, greenPct, yellowPct);
+    currentMixingZones = results;
+    currentAxisRows = buildAxisRows(results);
+    renderResultsCards(results, elements, { anchor, greenPct, yellowPct });
+    renderAxis(currentAxisRows, elements);
+    toggleResultsVisibility(elements, true);
+    updateQuickAnchorSelection(anchor);
   };
 
-  [elements.anchorSelect, elements.greenSelect, elements.yellowSelect].forEach((select) => {
-    select.addEventListener('change', handleChange);
-  });
+  initQuickAnchors(elements, handleChange);
+  initPresetsSection(elements, handleChange);
+
+  elements.anchorSelect.addEventListener('change', handleChange);
+  elements.greenSelect.addEventListener('change', handleChange);
+  elements.yellowSelect.addEventListener('change', handleChange);
+
+  if (elements.resetButton) {
+    elements.resetButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      resetToDefaults(elements, handleChange);
+      showFeedback(elements, 'Settings reset to defaults.', 'info');
+    });
+  }
+
+  if (elements.axisBody) {
+    elements.axisBody.addEventListener('click', (event) => handleAxisCopyClick(event, elements));
+  }
+  if (elements.copyAxisButton) {
+    elements.copyAxisButton.addEventListener('click', () => handleCopySummary(elements));
+  }
+  if (elements.copyCsvButton) {
+    elements.copyCsvButton.addEventListener('click', () => handleCopyCsv(elements));
+  }
+  if (elements.downloadCsvButton) {
+    elements.downloadCsvButton.addEventListener('click', () => handleDownloadCsv(elements));
+  }
 
   handleChange();
 }
 
 document.addEventListener('DOMContentLoaded', init);
-

--- a/src/ui-logic.js
+++ b/src/ui-logic.js
@@ -1,0 +1,231 @@
+import { formatBpm } from './calculation.js';
+
+const RANGE_TYPES = {
+  RANGE: 'range',
+  MAX: 'max',
+  MIN: 'min',
+  ANCHOR: 'anchor',
+};
+
+const ZONE_DESCRIPTIONS = {
+  up: {
+    Green: 'Optimal mix window (slower track)',
+    Yellow: 'Stretch / caution (slower track)',
+    Red: 'Out of range — too slow',
+  },
+  down: {
+    Green: 'Optimal mix window (faster track)',
+    Yellow: 'Stretch / caution (faster track)',
+    Red: 'Out of range — too fast',
+  },
+  anchor: 'Reference anchor tempo',
+};
+
+function clampRange(min, max) {
+  if (typeof min === 'number' && typeof max === 'number' && max < min) {
+    return { min, max: min };
+  }
+  return { min, max };
+}
+
+function formatRangeLabels(rangeType, minValue, maxValue) {
+  if (rangeType === RANGE_TYPES.RANGE) {
+    return {
+      minLabel: formatBpm(minValue),
+      maxLabel: formatBpm(maxValue),
+      rangeText: `${formatBpm(minValue)} – ${formatBpm(maxValue)}`,
+    };
+  }
+
+  if (rangeType === RANGE_TYPES.MAX) {
+    return {
+      minLabel: '—',
+      maxLabel: `≤ ${formatBpm(maxValue)}`,
+      rangeText: `≤ ${formatBpm(maxValue)}`,
+    };
+  }
+
+  if (rangeType === RANGE_TYPES.MIN) {
+    return {
+      minLabel: `≥ ${formatBpm(minValue)}`,
+      maxLabel: '—',
+      rangeText: `≥ ${formatBpm(minValue)}`,
+    };
+  }
+
+  return {
+    minLabel: formatBpm(minValue),
+    maxLabel: formatBpm(maxValue),
+    rangeText: formatBpm(minValue),
+  };
+}
+
+function buildRow({
+  id,
+  direction,
+  zone,
+  description,
+  rangeType,
+  minValue,
+  maxValue,
+  csvNote,
+}) {
+  const { min, max } = clampRange(minValue, maxValue);
+  const labels = formatRangeLabels(rangeType, min, max);
+  const copyText =
+    rangeType === RANGE_TYPES.ANCHOR
+      ? `${zone}: ${labels.rangeText}`
+      : `${direction} • ${zone}: ${labels.rangeText}`;
+
+  return {
+    id,
+    direction,
+    zone,
+    description,
+    rangeType,
+    minValue: min,
+    maxValue: max,
+    minLabel: labels.minLabel,
+    maxLabel: labels.maxLabel,
+    rangeText: labels.rangeText,
+    copyText,
+    csv: {
+      min: typeof min === 'number' ? String(min) : '',
+      max: typeof max === 'number' ? String(max) : '',
+      note: csvNote ?? description,
+    },
+  };
+}
+
+export function buildAxisRows(mixingZones) {
+  const { anchor, green, yellow } = mixingZones;
+
+  const anchorMinusOne = anchor - 1;
+  const anchorPlusOne = anchor + 1;
+
+  const upGreenMax = Math.max(green.up, anchorMinusOne);
+  const upYellowMax = Math.max(yellow.up, upGreenMax - 1);
+  const downGreenMin = Math.min(green.down, anchorPlusOne);
+  const downYellowMinCandidate = green.down + 1;
+  const downYellowMin = downYellowMinCandidate <= yellow.down ? downYellowMinCandidate : yellow.down;
+
+  const rows = [];
+
+  rows.push(
+    buildRow({
+      id: 'up-green',
+      direction: 'Upmix',
+      zone: 'Green',
+      description: ZONE_DESCRIPTIONS.up.Green,
+      rangeType: RANGE_TYPES.RANGE,
+      minValue: green.up,
+      maxValue: upGreenMax,
+    }),
+  );
+
+  rows.push(
+    buildRow({
+      id: 'up-yellow',
+      direction: 'Upmix',
+      zone: 'Yellow',
+      description: ZONE_DESCRIPTIONS.up.Yellow,
+      rangeType: RANGE_TYPES.RANGE,
+      minValue: yellow.up,
+      maxValue: upYellowMax,
+    }),
+  );
+
+  rows.push(
+    buildRow({
+      id: 'up-red',
+      direction: 'Upmix',
+      zone: 'Red',
+      description: ZONE_DESCRIPTIONS.up.Red,
+      rangeType: RANGE_TYPES.MAX,
+      minValue: null,
+      maxValue: yellow.up - 1,
+      csvNote: `${ZONE_DESCRIPTIONS.up.Red} (≤ ${formatBpm(yellow.up - 1)})`,
+    }),
+  );
+
+  rows.push(
+    buildRow({
+      id: 'anchor',
+      direction: 'Anchor',
+      zone: 'Anchor BPM',
+      description: ZONE_DESCRIPTIONS.anchor,
+      rangeType: RANGE_TYPES.ANCHOR,
+      minValue: anchor,
+      maxValue: anchor,
+    }),
+  );
+
+  rows.push(
+    buildRow({
+      id: 'down-green',
+      direction: 'Downmix',
+      zone: 'Green',
+      description: ZONE_DESCRIPTIONS.down.Green,
+      rangeType: RANGE_TYPES.RANGE,
+      minValue: downGreenMin,
+      maxValue: green.down,
+    }),
+  );
+
+  rows.push(
+    buildRow({
+      id: 'down-yellow',
+      direction: 'Downmix',
+      zone: 'Yellow',
+      description: ZONE_DESCRIPTIONS.down.Yellow,
+      rangeType: RANGE_TYPES.RANGE,
+      minValue: downYellowMin,
+      maxValue: yellow.down,
+    }),
+  );
+
+  rows.push(
+    buildRow({
+      id: 'down-red',
+      direction: 'Downmix',
+      zone: 'Red',
+      description: ZONE_DESCRIPTIONS.down.Red,
+      rangeType: RANGE_TYPES.MIN,
+      minValue: yellow.down + 1,
+      maxValue: null,
+      csvNote: `${ZONE_DESCRIPTIONS.down.Red} (≥ ${formatBpm(yellow.down + 1)})`,
+    }),
+  );
+
+  return rows;
+}
+
+function escapeCsvValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const stringValue = String(value);
+  if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+  return stringValue;
+}
+
+export function buildAxisCsv(rows, anchor) {
+  const lines = [
+    ['Direction', 'Zone', 'Min BPM', 'Max BPM', 'Anchor BPM', 'Notes'],
+    ...rows.map((row) => [
+      row.direction,
+      row.zone,
+      row.csv.min,
+      row.csv.max,
+      String(anchor),
+      row.csv.note,
+    ]),
+  ];
+
+  return lines.map((line) => line.map(escapeCsvValue).join(',')).join('\r\n');
+}
+
+export const RANGE_TYPE = RANGE_TYPES;

--- a/tests/calculation.test.js
+++ b/tests/calculation.test.js
@@ -3,6 +3,10 @@ import assert from 'node:assert/strict';
 import {
   ANCHOR_MIN,
   ANCHOR_MAX,
+  GREEN_MIN,
+  GREEN_MAX,
+  YELLOW_MIN,
+  YELLOW_MAX,
   DEFAULT_ANCHOR,
   DEFAULT_GREEN_DEV,
   DEFAULT_YELLOW_DEV,
@@ -56,24 +60,85 @@ describe('validateInputs', () => {
   it('returns valid when all constraints pass', () => {
     assert.deepEqual(validateInputs(DEFAULT_ANCHOR, DEFAULT_GREEN_DEV, DEFAULT_YELLOW_DEV), {
       valid: true,
+      errors: {},
     });
   });
 
   it('rejects anchors outside of range', () => {
-    assert.deepEqual(validateInputs(ANCHOR_MIN - 1, DEFAULT_GREEN_DEV, DEFAULT_YELLOW_DEV), {
+    const lowAnchor = validateInputs(ANCHOR_MIN - 1, DEFAULT_GREEN_DEV, DEFAULT_YELLOW_DEV);
+    assert.deepEqual(lowAnchor, {
       valid: false,
+      field: 'anchor',
       message: `Anchor BPM must be between ${ANCHOR_MIN} and ${ANCHOR_MAX}.`,
+      errors: {
+        anchor: `Anchor BPM must be between ${ANCHOR_MIN} and ${ANCHOR_MAX}.`,
+      },
     });
-    assert.deepEqual(validateInputs(ANCHOR_MAX + 1, DEFAULT_GREEN_DEV, DEFAULT_YELLOW_DEV), {
+
+    const highAnchor = validateInputs(ANCHOR_MAX + 1, DEFAULT_GREEN_DEV, DEFAULT_YELLOW_DEV);
+    assert.deepEqual(highAnchor, {
       valid: false,
+      field: 'anchor',
       message: `Anchor BPM must be between ${ANCHOR_MIN} and ${ANCHOR_MAX}.`,
+      errors: {
+        anchor: `Anchor BPM must be between ${ANCHOR_MIN} and ${ANCHOR_MAX}.`,
+      },
     });
   });
 
   it('rejects when yellow deviation is not greater than green', () => {
-    assert.deepEqual(validateInputs(DEFAULT_ANCHOR, 8, 6), {
+    const invalid = validateInputs(DEFAULT_ANCHOR, 8, 6);
+    assert.deepEqual(invalid, {
       valid: false,
+      field: 'yellow',
       message: 'Yellow deviation must be greater than green deviation.',
+      errors: {
+        yellow: 'Yellow deviation must be greater than green deviation.',
+      },
+    });
+  });
+
+  it('rejects non-integer anchors and deviations', () => {
+    const anchorResult = validateInputs(DEFAULT_ANCHOR + 0.5, DEFAULT_GREEN_DEV, DEFAULT_YELLOW_DEV);
+    assert.deepEqual(anchorResult, {
+      valid: false,
+      field: 'anchor',
+      message: 'Anchor BPM must be a whole number.',
+      errors: {
+        anchor: 'Anchor BPM must be a whole number.',
+      },
+    });
+
+    const greenResult = validateInputs(DEFAULT_ANCHOR, DEFAULT_GREEN_DEV + 0.1, DEFAULT_YELLOW_DEV);
+    assert.deepEqual(greenResult, {
+      valid: false,
+      field: 'green',
+      message: 'Green deviation must be a whole number.',
+      errors: {
+        green: 'Green deviation must be a whole number.',
+      },
+    });
+  });
+
+  it('rejects deviations that exceed configured bounds', () => {
+    const greenTooHigh = validateInputs(DEFAULT_ANCHOR, GREEN_MAX + 1, DEFAULT_YELLOW_DEV);
+    assert.deepEqual(greenTooHigh, {
+      valid: false,
+      field: 'green',
+      message: `Green deviation must be between ${GREEN_MIN}% and ${GREEN_MAX}%.`,
+      errors: {
+        green: `Green deviation must be between ${GREEN_MIN}% and ${GREEN_MAX}%.`,
+      },
+    });
+
+    const yellowTooLow = validateInputs(DEFAULT_ANCHOR, DEFAULT_GREEN_DEV, YELLOW_MIN - 1);
+    assert.deepEqual(yellowTooLow, {
+      valid: false,
+      field: 'yellow',
+      message: `Yellow deviation must be between ${YELLOW_MIN}% and ${YELLOW_MAX}%.`,
+      errors: {
+        yellow: `Yellow deviation must be between ${YELLOW_MIN}% and ${YELLOW_MAX}%.`,
+      },
     });
   });
 });

--- a/tests/ui-logic.test.js
+++ b/tests/ui-logic.test.js
@@ -1,0 +1,181 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DEFAULT_ANCHOR,
+  DEFAULT_GREEN_DEV,
+  DEFAULT_YELLOW_DEV,
+  calculateMixingZones,
+} from '../src/calculation.js';
+import { buildAxisRows, buildAxisCsv } from '../src/ui-logic.js';
+
+const DEFAULT_ROWS_SNAPSHOT = [
+  {
+    id: 'up-green',
+    direction: 'Upmix',
+    zone: 'Green',
+    description: 'Optimal mix window (slower track)',
+    rangeType: 'range',
+    minValue: 125,
+    maxValue: 132,
+    minLabel: '125 BPM',
+    maxLabel: '132 BPM',
+    rangeText: '125 BPM – 132 BPM',
+    copyText: 'Upmix • Green: 125 BPM – 132 BPM',
+    csv: {
+      min: '125',
+      max: '132',
+      note: 'Optimal mix window (slower track)',
+    },
+  },
+  {
+    id: 'up-yellow',
+    direction: 'Upmix',
+    zone: 'Yellow',
+    description: 'Stretch / caution (slower track)',
+    rangeType: 'range',
+    minValue: 122,
+    maxValue: 131,
+    minLabel: '122 BPM',
+    maxLabel: '131 BPM',
+    rangeText: '122 BPM – 131 BPM',
+    copyText: 'Upmix • Yellow: 122 BPM – 131 BPM',
+    csv: {
+      min: '122',
+      max: '131',
+      note: 'Stretch / caution (slower track)',
+    },
+  },
+  {
+    id: 'up-red',
+    direction: 'Upmix',
+    zone: 'Red',
+    description: 'Out of range — too slow',
+    rangeType: 'max',
+    minValue: null,
+    maxValue: 121,
+    minLabel: '—',
+    maxLabel: '≤ 121 BPM',
+    rangeText: '≤ 121 BPM',
+    copyText: 'Upmix • Red: ≤ 121 BPM',
+    csv: {
+      min: '',
+      max: '121',
+      note: 'Out of range — too slow (≤ 121 BPM)',
+    },
+  },
+  {
+    id: 'anchor',
+    direction: 'Anchor',
+    zone: 'Anchor BPM',
+    description: 'Reference anchor tempo',
+    rangeType: 'anchor',
+    minValue: 133,
+    maxValue: 133,
+    minLabel: '133 BPM',
+    maxLabel: '133 BPM',
+    rangeText: '133 BPM',
+    copyText: 'Anchor BPM: 133 BPM',
+    csv: {
+      min: '133',
+      max: '133',
+      note: 'Reference anchor tempo',
+    },
+  },
+  {
+    id: 'down-green',
+    direction: 'Downmix',
+    zone: 'Green',
+    description: 'Optimal mix window (faster track)',
+    rangeType: 'range',
+    minValue: 134,
+    maxValue: 141,
+    minLabel: '134 BPM',
+    maxLabel: '141 BPM',
+    rangeText: '134 BPM – 141 BPM',
+    copyText: 'Downmix • Green: 134 BPM – 141 BPM',
+    csv: {
+      min: '134',
+      max: '141',
+      note: 'Optimal mix window (faster track)',
+    },
+  },
+  {
+    id: 'down-yellow',
+    direction: 'Downmix',
+    zone: 'Yellow',
+    description: 'Stretch / caution (faster track)',
+    rangeType: 'range',
+    minValue: 142,
+    maxValue: 144,
+    minLabel: '142 BPM',
+    maxLabel: '144 BPM',
+    rangeText: '142 BPM – 144 BPM',
+    copyText: 'Downmix • Yellow: 142 BPM – 144 BPM',
+    csv: {
+      min: '142',
+      max: '144',
+      note: 'Stretch / caution (faster track)',
+    },
+  },
+  {
+    id: 'down-red',
+    direction: 'Downmix',
+    zone: 'Red',
+    description: 'Out of range — too fast',
+    rangeType: 'min',
+    minValue: 145,
+    maxValue: null,
+    minLabel: '≥ 145 BPM',
+    maxLabel: '—',
+    rangeText: '≥ 145 BPM',
+    copyText: 'Downmix • Red: ≥ 145 BPM',
+    csv: {
+      min: '145',
+      max: '',
+      note: 'Out of range — too fast (≥ 145 BPM)',
+    },
+  },
+];
+
+describe('buildAxisRows', () => {
+  it('produces the expected row snapshot for default values', () => {
+    const zones = calculateMixingZones(DEFAULT_ANCHOR, DEFAULT_GREEN_DEV, DEFAULT_YELLOW_DEV);
+    const rows = buildAxisRows(zones);
+    assert.deepEqual(rows, DEFAULT_ROWS_SNAPSHOT);
+  });
+
+  it('normalises overlapping ranges to keep the axis monotonic', () => {
+    const edgeZones = calculateMixingZones(60, 1, 2);
+    const rows = buildAxisRows(edgeZones);
+    const upYellow = rows.find((row) => row.id === 'up-yellow');
+    const upRed = rows.find((row) => row.id === 'up-red');
+
+    assert.ok(upYellow);
+    assert.ok(upRed);
+    assert.strictEqual(upYellow.minValue, upYellow.maxValue);
+    assert.strictEqual(upYellow.minLabel, upYellow.maxLabel);
+    assert.ok(typeof upRed.maxValue === 'number');
+    assert.ok(upRed.maxValue < upYellow.minValue);
+  });
+});
+
+describe('buildAxisCsv', () => {
+  it('serialises rows into a Rekordbox-friendly CSV', () => {
+    const zones = calculateMixingZones(DEFAULT_ANCHOR, DEFAULT_GREEN_DEV, DEFAULT_YELLOW_DEV);
+    const rows = buildAxisRows(zones);
+    const csv = buildAxisCsv(rows, zones.anchor);
+
+    const expected = [
+      'Direction,Zone,Min BPM,Max BPM,Anchor BPM,Notes',
+      'Upmix,Green,125,132,133,Optimal mix window (slower track)',
+      'Upmix,Yellow,122,131,133,Stretch / caution (slower track)',
+      'Upmix,Red,,121,133,Out of range — too slow (≤ 121 BPM)',
+      'Anchor,Anchor BPM,133,133,133,Reference anchor tempo',
+      'Downmix,Green,134,141,133,Optimal mix window (faster track)',
+      'Downmix,Yellow,142,144,133,Stretch / caution (faster track)',
+      'Downmix,Red,145,,133,Out of range — too fast (≥ 145 BPM)',
+    ].join('\r\n');
+
+    assert.equal(csv, expected);
+  });
+});


### PR DESCRIPTION
## Summary
- sync the deployed docs UI with the new phase 1 experience, including inline validation, quick anchors, presets, and enhanced axis copy/export controls
- bundle the hardened client logic for clipboard feedback, Rekordbox CSV generation, and localStorage preset management into the published assets
- annotate the roadmap so phases 0 and 1 are explicitly marked complete

## Testing
- npm run lint
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc1cde36f883268ebe4e0c546812d8