### PR TITLE
Add playlist export workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,6 +216,75 @@
               </div>
               <div id="axis-empty-state" class="border-t border-slate-700/60 p-5 text-sm text-slate-400">Adjust parameters to generate the axis ranges.</div>
             </div>
+            <div class="mt-10 space-y-6 rounded-xl border border-slate-700/60 bg-slate-800/70 p-6 shadow-lg">
+              <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div class="lg:max-w-xl">
+                  <h3 class="text-xl font-bold text-slate-100">Playlist workflow &amp; Rekordbox export</h3>
+                  <p class="mt-1 text-sm text-slate-400">Paste a CSV with Title, Artist, BPM to label tracks against this anchor and build a Rekordbox-friendly template.</p>
+                  <ul class="mt-3 list-disc space-y-1 pl-5 text-xs text-slate-500">
+                    <li>In Rekordbox, export a playlist to CSV to reuse the headers before pasting here.</li>
+                    <li>Use the filters to include only tracks you want in the static playlist.</li>
+                    <li>Import the downloaded CSV via <span class="font-semibold text-slate-300">File → Import Playlist</span>.</li>
+                  </ul>
+                </div>
+                <label class="flex w-full flex-col gap-2 text-sm text-slate-300 lg:w-1/2">
+                  <span class="font-medium">Paste playlist CSV</span>
+                  <textarea id="playlist-input" rows="8" placeholder="Title,Artist,BPM&#10;Track One,DJ Example,128" class="w-full rounded-md border border-slate-700/70 bg-slate-900/70 px-3 py-2 text-slate-100 placeholder:text-slate-500 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"></textarea>
+                </label>
+              </div>
+              <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                <div class="flex flex-wrap items-center gap-3">
+                  <button id="preview-playlist" type="button" class="inline-flex items-center justify-center rounded-md border border-teal-500/60 bg-teal-700/80 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-teal-600/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900">Preview &amp; tag tracks</button>
+                  <button id="copy-playlist-template" type="button" class="inline-flex items-center justify-center rounded-md border border-slate-600/70 bg-slate-900/70 px-4 py-2 text-sm text-slate-200 transition-colors hover:bg-teal-700/80 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-50" disabled>Copy playlist template</button>
+                  <button id="download-playlist" type="button" class="inline-flex items-center justify-center rounded-md border border-indigo-500/60 bg-indigo-700/80 px-4 py-2 text-sm text-white transition-colors hover:bg-indigo-600/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-50" disabled>Make static playlist (CSV)</button>
+                </div>
+                <div id="playlist-filter" class="flex flex-wrap items-center gap-3 text-sm text-slate-300">
+                  <span class="font-medium">Include:</span>
+                  <label class="inline-flex items-center gap-2">
+                    <input type="checkbox" data-filter-status="yes" class="h-4 w-4 rounded border-slate-600 bg-slate-900 text-teal-500 focus:ring-teal-400" checked />
+                    <span>Fits (Yes)</span>
+                  </label>
+                  <label class="inline-flex items-center gap-2">
+                    <input type="checkbox" data-filter-status="edge" class="h-4 w-4 rounded border-slate-600 bg-slate-900 text-amber-400 focus:ring-amber-300" checked />
+                    <span>Edge (Caution)</span>
+                  </label>
+                  <label class="inline-flex items-center gap-2">
+                    <input type="checkbox" data-filter-status="no" class="h-4 w-4 rounded border-slate-600 bg-slate-900 text-rose-400 focus:ring-rose-300" />
+                    <span>Outside (No)</span>
+                  </label>
+                </div>
+              </div>
+              <p id="playlist-feedback" class="min-h-[1.5rem] text-sm text-slate-200" aria-live="polite"></p>
+              <div class="space-y-4">
+                <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <h4 class="text-lg font-semibold text-slate-100">Playlist preview</h4>
+                  <p id="playlist-summary" class="text-sm text-slate-400"></p>
+                </div>
+                <div class="overflow-x-auto rounded-lg border border-slate-700/60 bg-slate-900/70">
+                  <table class="w-full min-w-[920px] text-left text-sm text-slate-200">
+                    <thead class="bg-slate-900/70 text-xs uppercase tracking-wide text-slate-300">
+                      <tr>
+                        <th class="px-4 py-3">Title</th>
+                        <th class="px-4 py-3">Artist</th>
+                        <th class="px-4 py-3">BPM</th>
+                        <th class="px-4 py-3">Fits</th>
+                        <th class="px-4 py-3">Zone</th>
+                        <th class="px-4 py-3">Δ BPM</th>
+                        <th class="px-4 py-3">Δ %</th>
+                        <th class="px-4 py-3">Notes</th>
+                      </tr>
+                    </thead>
+                    <tbody id="playlist-preview-body" class="divide-y divide-slate-800/60"></tbody>
+                  </table>
+                  <div id="playlist-empty-state" class="px-4 py-5 text-sm text-slate-400">Paste a playlist to preview matches.</div>
+                </div>
+              </div>
+              <div id="playlist-excluded" class="hidden rounded-lg border border-slate-700/60 bg-slate-900/70 p-4">
+                <h4 class="text-sm font-semibold text-slate-200">Excluded from export</h4>
+                <p class="mt-1 text-xs text-slate-400">Tracks listed here are outside the window or missing BPM and will not appear in the exported CSV.</p>
+                <ul id="playlist-excluded-list" class="mt-3 space-y-2 text-sm text-slate-300"></ul>
+              </div>
+            </div>
           </section>
       </main>
     </div>

--- a/roadmap.md
+++ b/roadmap.md
@@ -51,7 +51,8 @@ UX notes: Keep Axis numeric layout (monotonic left→right), percent display for
 
 ---
 
-## Phase 2 — Playlist workflow & Rekordbox friendliness *(MEDIUM)*
+## Phase 2 — Playlist workflow & Rekordbox friendliness *(MEDIUM)* ✅ Completed
+**Status:** ✅ Completed.
 **Goal:** Save DJs time when making playlists.
 
 **Tasks**

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -1,0 +1,347 @@
+import { formatBpm } from './calculation.js';
+
+const HEADER_ALIASES = {
+  title: ['title', 'track title', 'track', 'name'],
+  artist: ['artist', 'artists'],
+  bpm: ['bpm', 'tempo', 'bpm (analysis)', 'analyzed bpm', 'detected bpm'],
+};
+
+const STATUS_LABELS = {
+  yes: 'Yes',
+  edge: 'Edge',
+  no: 'No',
+  invalid: '—',
+};
+
+const ZONE_LABELS = {
+  yes: 'Green',
+  edge: 'Yellow',
+  no: 'Red',
+  invalid: '—',
+};
+
+const DELIMITER_CANDIDATES = [',', ';', '\t'];
+
+function normaliseHeader(value) {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+function findHeaderIndex(headers, key) {
+  const aliases = HEADER_ALIASES[key];
+  for (let index = 0; index < headers.length; index += 1) {
+    const header = normaliseHeader(headers[index]);
+    if (aliases.some((alias) => header === alias || header.includes(alias))) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function detectDelimiter(sampleLine) {
+  for (const delimiter of DELIMITER_CANDIDATES) {
+    const count = sampleLine.split(delimiter).length - 1;
+    if (count > 0) {
+      return delimiter;
+    }
+  }
+  return ',';
+}
+
+function splitCsvLine(line, delimiter) {
+  const result = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+
+    if (char === '"') {
+      const peekNext = line[index + 1];
+      if (inQuotes && peekNext === '"') {
+        current += '"';
+        index += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === delimiter && !inQuotes) {
+      result.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  result.push(current);
+  return result.map((value) => value.trim());
+}
+
+function parseBpm(value) {
+  if (!value || typeof value !== 'string') {
+    return { bpm: null, raw: '' };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { bpm: null, raw: '' };
+  }
+  const normalised = trimmed.replace(/,/g, '.');
+  const parsed = Number.parseFloat(normalised);
+  if (Number.isFinite(parsed)) {
+    return { bpm: parsed, raw: trimmed };
+  }
+  return { bpm: null, raw: trimmed };
+}
+
+export function parsePlaylistInput(text) {
+  if (typeof text !== 'string' || !text.trim()) {
+    return { tracks: [], errors: ['Paste a CSV with Title, Artist, BPM columns.'] };
+  }
+
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (!lines.length) {
+    return { tracks: [], errors: ['Paste a CSV with Title, Artist, BPM columns.'] };
+  }
+
+  const delimiter = detectDelimiter(lines[0]);
+  const headers = splitCsvLine(lines[0], delimiter);
+
+  const titleIndex = findHeaderIndex(headers, 'title');
+  const artistIndex = findHeaderIndex(headers, 'artist');
+  const bpmIndex = findHeaderIndex(headers, 'bpm');
+
+  if (titleIndex === -1 || artistIndex === -1 || bpmIndex === -1) {
+    return {
+      tracks: [],
+      errors: ['CSV header must include Title, Artist, and BPM columns.'],
+    };
+  }
+
+  const tracks = [];
+
+  for (let lineIndex = 1; lineIndex < lines.length; lineIndex += 1) {
+    const cells = splitCsvLine(lines[lineIndex], delimiter);
+    const title = cells[titleIndex] ?? '';
+    const artist = cells[artistIndex] ?? '';
+    const bpmCell = cells[bpmIndex] ?? '';
+
+    if (!title && !artist && !bpmCell) {
+      continue;
+    }
+
+    const { bpm, raw } = parseBpm(bpmCell);
+
+    tracks.push({
+      rowNumber: lineIndex + 1,
+      title,
+      artist,
+      bpm,
+      bpmRaw: raw,
+    });
+  }
+
+  if (!tracks.length) {
+    return {
+      tracks: [],
+      errors: ['No tracks detected. Ensure the CSV has data rows.'],
+    };
+  }
+
+  return { tracks, errors: [] };
+}
+
+function formatNumber(value, digits = 2) {
+  if (!Number.isFinite(value)) {
+    return '—';
+  }
+  const rounded = Number.parseFloat(value.toFixed(digits));
+  if (Number.isInteger(rounded)) {
+    return String(rounded);
+  }
+  return rounded.toString();
+}
+
+function formatSigned(value, unit) {
+  if (!Number.isFinite(value)) {
+    return '—';
+  }
+  if (Object.is(value, -0)) {
+    return `0 ${unit}`;
+  }
+  if (Math.abs(value) < 0.005) {
+    return `0 ${unit}`;
+  }
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${formatNumber(value)} ${unit}`;
+}
+
+function describeDelta(anchor, bpm) {
+  if (!Number.isFinite(bpm)) {
+    return 'BPM unavailable';
+  }
+  const deltaBpm = bpm - anchor;
+  if (Math.abs(deltaBpm) < 0.005) {
+    return 'Matches anchor BPM';
+  }
+  const deltaPercent = (deltaBpm / anchor) * 100;
+  const direction = deltaBpm > 0 ? 'faster' : 'slower';
+  return `${formatSigned(deltaBpm, 'BPM')} (${formatSigned(deltaPercent, '%')} ${direction})`;
+}
+
+function classifyTrack(track, context) {
+  const { anchor, greenPct, yellowPct, mixingZones } = context;
+  if (!Number.isFinite(track.bpm)) {
+    return {
+      ...track,
+      status: 'invalid',
+      fitsLabel: STATUS_LABELS.invalid,
+      zoneLabel: ZONE_LABELS.invalid,
+      deltaBpm: null,
+      deltaPercent: null,
+      deltaBpmLabel: '—',
+      deltaPercentLabel: '—',
+      note: 'Missing or invalid BPM',
+      bpmLabel: track.bpmRaw || '—',
+    };
+  }
+
+  const { bpm } = track;
+  const deltaBpm = bpm - anchor;
+  const deltaPercent = (deltaBpm / anchor) * 100;
+  const deltaBpmLabel = formatSigned(deltaBpm, 'BPM');
+  const deltaPercentLabel = formatSigned(deltaPercent, '%');
+  const withinGreen = bpm >= mixingZones.green.up && bpm <= mixingZones.green.down;
+  const withinYellow = bpm >= mixingZones.yellow.up && bpm <= mixingZones.yellow.down;
+
+  if (withinGreen) {
+    return {
+      ...track,
+      status: 'yes',
+      fitsLabel: STATUS_LABELS.yes,
+      zoneLabel: ZONE_LABELS.yes,
+      deltaBpm,
+      deltaPercent,
+      deltaBpmLabel,
+      deltaPercentLabel,
+      note: `Within ±${greenPct}% window — ${describeDelta(anchor, bpm)}`,
+      bpmLabel: formatNumber(bpm),
+    };
+  }
+
+  if (withinYellow) {
+    return {
+      ...track,
+      status: 'edge',
+      fitsLabel: STATUS_LABELS.edge,
+      zoneLabel: ZONE_LABELS.edge,
+      deltaBpm,
+      deltaPercent,
+      deltaBpmLabel,
+      deltaPercentLabel,
+      note: `Within caution window (±${yellowPct}%) — ${describeDelta(anchor, bpm)}`,
+      bpmLabel: formatNumber(bpm),
+    };
+  }
+
+  return {
+    ...track,
+    status: 'no',
+    fitsLabel: STATUS_LABELS.no,
+    zoneLabel: ZONE_LABELS.no,
+    deltaBpm,
+    deltaPercent,
+    deltaBpmLabel,
+    deltaPercentLabel,
+    note: `Outside ±${yellowPct}% window — ${describeDelta(anchor, bpm)}`,
+    bpmLabel: formatNumber(bpm),
+  };
+}
+
+export function scoreTracks(tracks, context) {
+  const counts = {
+    total: tracks.length,
+    yes: 0,
+    edge: 0,
+    no: 0,
+    invalid: 0,
+  };
+  const entries = tracks.map((track) => {
+    const entry = classifyTrack(track, context);
+    counts[entry.status] += 1;
+    return entry;
+  });
+  return { entries, counts };
+}
+
+export function createDefaultFilters() {
+  return {
+    yes: true,
+    edge: true,
+    no: false,
+  };
+}
+
+export function filterPlaylistEntries(entries, filters) {
+  const included = [];
+  const excluded = [];
+
+  entries.forEach((entry) => {
+    if (entry.status === 'invalid') {
+      excluded.push(entry);
+    } else if (filters[entry.status]) {
+      included.push(entry);
+    } else {
+      excluded.push(entry);
+    }
+  });
+
+  return { included, excluded };
+}
+
+function escapeCsvValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  const stringValue = String(value);
+  if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+  return stringValue;
+}
+
+export function buildPlaylistCsv(entries, anchor) {
+  const header = [
+    'Title',
+    'Artist',
+    'BPM',
+    'Fits',
+    'Zone',
+    'Delta (BPM)',
+    'Delta (%)',
+    'Notes',
+    'Anchor BPM',
+  ];
+
+  const lines = [header];
+
+  entries.forEach((entry) => {
+    lines.push([
+      entry.title,
+      entry.artist,
+      Number.isFinite(entry.bpm) ? formatNumber(entry.bpm) : '',
+      entry.fitsLabel,
+      entry.zoneLabel,
+      entry.deltaBpmLabel,
+      entry.deltaPercentLabel,
+      entry.note,
+      formatBpm(anchor),
+    ]);
+  });
+
+  return lines.map((line) => line.map(escapeCsvValue).join(',')).join('\r\n');
+}
+
+export const PLAYLIST_STATUS_LABELS = STATUS_LABELS;
+export const PLAYLIST_ZONE_LABELS = ZONE_LABELS;

--- a/tests/playlist.test.js
+++ b/tests/playlist.test.js
@@ -1,0 +1,134 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { calculateMixingZones } from '../src/calculation.js';
+import {
+  parsePlaylistInput,
+  scoreTracks,
+  filterPlaylistEntries,
+  buildPlaylistCsv,
+  createDefaultFilters,
+} from '../src/playlist.js';
+
+function buildTrack(rowNumber, title, artist, bpm, bpmRaw = bpm === null ? '' : String(bpm)) {
+  return { rowNumber, title, artist, bpm, bpmRaw };
+}
+
+describe('parsePlaylistInput', () => {
+  it('parses CSV content with quoted values and decimals', () => {
+    const input = ['Title,Artist,BPM', '"Track One","DJ Example",128', 'Track Two,Artist B,130.5'].join('\n');
+    const result = parsePlaylistInput(input);
+
+    assert.deepEqual(result.errors, []);
+    assert.equal(result.tracks.length, 2);
+    assert.equal(result.tracks[0].title, 'Track One');
+    assert.equal(result.tracks[0].artist, 'DJ Example');
+    assert.equal(result.tracks[0].bpm, 128);
+    assert.equal(result.tracks[0].rowNumber, 2);
+    assert.equal(result.tracks[1].bpm, 130.5);
+  });
+
+  it('detects alternative headers and semicolon delimiters', () => {
+    const input = ['Track Title;Artists;Tempo', 'Edge Case;DJ Alias;131'].join('\n');
+    const result = parsePlaylistInput(input);
+
+    assert.deepEqual(result.errors, []);
+    assert.equal(result.tracks.length, 1);
+    assert.equal(result.tracks[0].title, 'Edge Case');
+    assert.equal(result.tracks[0].artist, 'DJ Alias');
+    assert.equal(result.tracks[0].bpm, 131);
+  });
+});
+
+describe('scoreTracks', () => {
+  const anchor = 133;
+  const greenPct = 6;
+  const yellowPct = 8;
+  const zones = calculateMixingZones(anchor, greenPct, yellowPct);
+  const context = { anchor, greenPct, yellowPct, mixingZones: zones };
+
+  it('classifies tracks into yes, edge, no, and invalid buckets', () => {
+    const tracks = [
+      buildTrack(2, 'Anchor', 'DJ A', 133),
+      buildTrack(3, 'Caution', 'DJ B', 122),
+      buildTrack(4, 'Outside', 'DJ C', 150),
+      buildTrack(5, 'Unknown', 'DJ D', null, ''),
+    ];
+
+    const { entries, counts } = scoreTracks(tracks, context);
+
+    assert.equal(entries.length, 4);
+    assert.deepEqual(
+      entries.map((entry) => entry.status),
+      ['yes', 'edge', 'no', 'invalid'],
+    );
+    assert.equal(counts.yes, 1);
+    assert.equal(counts.edge, 1);
+    assert.equal(counts.no, 1);
+    assert.equal(counts.invalid, 1);
+
+    const yesEntry = entries[0];
+    assert.equal(yesEntry.fitsLabel, 'Yes');
+    assert.equal(yesEntry.zoneLabel, 'Green');
+    assert.equal(yesEntry.deltaBpmLabel, '0 BPM');
+    assert.equal(yesEntry.note, 'Within ±6% window — Matches anchor BPM');
+
+    const edgeEntry = entries[1];
+    assert.equal(edgeEntry.fitsLabel, 'Edge');
+    assert.equal(edgeEntry.zoneLabel, 'Yellow');
+    assert.ok(edgeEntry.note.startsWith('Within caution window (±8%)'));
+
+    const noEntry = entries[2];
+    assert.equal(noEntry.fitsLabel, 'No');
+    assert.equal(noEntry.zoneLabel, 'Red');
+    assert.ok(noEntry.note.startsWith('Outside ±8% window'));
+
+    const invalidEntry = entries[3];
+    assert.equal(invalidEntry.fitsLabel, '—');
+    assert.equal(invalidEntry.zoneLabel, '—');
+    assert.equal(invalidEntry.note, 'Missing or invalid BPM');
+  });
+
+  it('filters playlist entries based on export toggles', () => {
+    const tracks = [
+      buildTrack(2, 'Anchor', 'DJ A', 133),
+      buildTrack(3, 'Caution', 'DJ B', 122),
+      buildTrack(4, 'Outside', 'DJ C', 150),
+      buildTrack(5, 'Unknown', 'DJ D', null, ''),
+    ];
+
+    const { entries } = scoreTracks(tracks, context);
+    const filters = createDefaultFilters();
+
+    let { included, excluded } = filterPlaylistEntries(entries, filters);
+    assert.equal(included.length, 2);
+    assert.equal(excluded.length, 2);
+    assert.ok(included.every((entry) => entry.status === 'yes' || entry.status === 'edge'));
+
+    filters.no = true;
+    ({ included, excluded } = filterPlaylistEntries(entries, filters));
+    assert.equal(included.length, 3);
+    assert.equal(excluded.length, 1);
+    assert.ok(excluded.every((entry) => entry.status === 'invalid'));
+  });
+
+  it('serialises filtered entries into a Rekordbox friendly CSV', () => {
+    const tracks = [
+      buildTrack(2, 'Anchor', 'DJ A', 133),
+      buildTrack(3, 'Caution', 'DJ B', 122),
+      buildTrack(4, 'Outside', 'DJ C', 150),
+    ];
+
+    const { entries } = scoreTracks(tracks, context);
+    const filters = createDefaultFilters();
+    const { included } = filterPlaylistEntries(entries, filters);
+    const csv = buildPlaylistCsv(included, anchor);
+
+    const expected = [
+      'Title,Artist,BPM,Fits,Zone,Delta (BPM),Delta (%),Notes,Anchor BPM',
+      'Anchor,DJ A,133,Yes,Green,0 BPM,0 %,Within ±6% window — Matches anchor BPM,133 BPM',
+      'Caution,DJ B,122,Edge,Yellow,-11 BPM,-8.27 %,Within caution window (±8%) — -11 BPM (-8.27 % slower),133 BPM',
+    ].join('\r\n');
+
+    assert.equal(csv, expected);
+  });
+});


### PR DESCRIPTION
## Summary
- add playlist parsing, scoring, and CSV export utilities to support Rekordbox workflows
- extend the UI with playlist preview, filtering, and copy/download controls powered by the new playlist module
- mark phase 2 of the roadmap as complete and add regression tests for playlist parsing and export logic

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc3af600848326953d81723a6f511c